### PR TITLE
Fix the generated res url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Idea stuff
 build
 generated
 src/generated
@@ -8,6 +9,7 @@ classes
 .gradle
 gradle/ext/
 /bin/
+out/
 
 # Eclipse
 .project

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -129,6 +129,7 @@ public class CatalogObjectController {
         try {
             CatalogObjectMetadata metadata = catalogObjectService.getCatalogObjectMetadata(bucketId, decodedName);
             metadata.add(LinkUtil.createLink(metadata.getBucketId(), metadata.getName()));
+            metadata.add(LinkUtil.createRelativeLink(metadata.getBucketId(), metadata.getName()));
             return ResponseEntity.ok(metadata);
         } catch (CatalogObjectNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e);
@@ -219,8 +220,10 @@ public class CatalogObjectController {
             } else {
                 metadataList = catalogObjectService.listCatalogObjects(bucketId);
             }
-            metadataList.stream()
-                        .forEach(object -> object.add(LinkUtil.createLink(object.getBucketId(), object.getName())));
+            metadataList.stream().forEach(object -> {
+                object.add(LinkUtil.createLink(object.getBucketId(), object.getName()));
+                object.add(LinkUtil.createRelativeLink(object.getBucketId(), object.getName()));
+            });
             return ResponseEntity.ok(metadataList);
         }
     }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
@@ -100,6 +100,9 @@ public class CatalogObjectRevisionController {
                                                                                            decodedName,
                                                                                            commitTime);
             metadata.add(LinkUtil.createLink(metadata.getBucketId(), metadata.getName(), metadata.getCommitDateTime()));
+            metadata.add(LinkUtil.createRelativeLink(metadata.getBucketId(),
+                                                     metadata.getName(),
+                                                     metadata.getCommitDateTime()));
             return ResponseEntity.ok(metadata);
         } catch (RevisionNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
@@ -143,6 +146,7 @@ public class CatalogObjectRevisionController {
 
         return catalogObjectMetadataList.stream().map(object -> {
             object.add(LinkUtil.createLink(object.getBucketId(), object.getName(), object.getCommitDateTime()));
+            object.add(LinkUtil.createRelativeLink(object.getBucketId(), object.getName(), object.getCommitDateTime()));
             return object;
         }).collect(Collectors.toList());
     }

--- a/src/main/java/org/ow2/proactive/catalog/util/LinkUtil.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/LinkUtil.java
@@ -48,6 +48,14 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class LinkUtil {
 
+    /**
+     * This is used to generate the absolute URL of the given object revision based on the service domain.
+     *
+     * @param bucketId The id of the bucket holding this object
+     * @param name The name of the object which is the identifier of the object
+     * @param commitTime The commit time of the object which is also the identifier of this revision
+     * @return a <code>Link</code> referencing the given object's revision raw content
+     */
     public static Link createLink(Long bucketId, String name, LocalDateTime commitTime) {
         try {
             long epochMilli = commitTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
@@ -63,6 +71,13 @@ public class LinkUtil {
         return null;
     }
 
+    /**
+     * This is used to generate the absolute URL of the given object based on the service domain.
+     *
+     * @param bucketId The id of the bucket holding this object
+     * @param name The name of the object which is the identifier of the object
+     * @return a <code>Link</code> referencing the given object's raw content
+     */
     public static Link createLink(Long bucketId, String name) {
         try {
             ControllerLinkBuilder controllerLinkBuilder = linkTo(methodOn(CatalogObjectController.class).getRaw(bucketId,
@@ -74,5 +89,47 @@ public class LinkUtil {
             log.error("{} cannot be encoded", name, e);
         }
         return null;
+    }
+
+    /**
+     * This is used to generate the relative URL of the given object revision.
+     * The URL will only contain the path <code>buckets/../resources/../revisions/../raw</code>.
+     *
+     * @param bucketId The id of the bucket holding this object
+     * @param objectName The name of the object which is the identifier of the object
+     * @param commitTime The commit time of the object which is also the identifier of this revision
+     * @return a <code>Link</code> referencing the given object's revision raw content
+     */
+    public static Link createRelativeLink(Long bucketId, String objectName, LocalDateTime commitTime) {
+        Link link = null;
+        try {
+            long epochMilli = commitTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            link = new Link("buckets/" + bucketId + "/resources/" + URLEncoder.encode(objectName, "UTF-8") +
+                            "/revisions/" + epochMilli).withRel("relative");
+
+        } catch (UnsupportedEncodingException e) {
+            log.error("{} cannot be encoded", objectName, e);
+        }
+        return link;
+    }
+
+    /**
+     * This is used to generate the relative URL of the given object.
+     * The URL will only contain the path <code>buckets/../resources/../raw</code>.
+     *
+     * @param bucketId The id of the bucket holding this object
+     * @param objectName The name of the object which is the identifier of the object
+     * @return a <code>Link</code> referencing the given object's raw content
+     */
+    public static Link createRelativeLink(Long bucketId, String objectName) {
+        Link link = null;
+        try {
+            link = new Link("buckets/" + bucketId + "/resources/" +
+                            URLEncoder.encode(objectName, "UTF-8")).withRel("relative");
+
+        } catch (UnsupportedEncodingException e) {
+            log.error("{} cannot be encoded", objectName, e);
+        }
+        return link;
     }
 }


### PR DESCRIPTION
When something (e.g a proxy or a router) is put in front of the catalog service, the absolute URL of the raw content in the HATEOAS payload is no longer valid. As the catalog service may not be aware of something between him and the client, we cannot rely on that URL anymore. I expose the relative path as another HATEOAS link called _relative_, leaving the domain resolution to the client side, which is already aware of the real domain exposed by the proxy or router since it managed to send a request to it in the first place.

This PR is associated with [this PR](https://github.com/ow2-proactive/studio/pull/392) as well.