### PR TITLE
Fix configuration bug and GROUP: prefix

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
@@ -67,7 +67,7 @@ import lombok.extern.log4j.Log4j2;
 @Transactional
 public class BucketService {
 
-    public static final String DEFAULT_BUCKET_OWNER = "public-objects";
+    public static final String DEFAULT_BUCKET_OWNER = AuthorizationService.GROUP_PREFIX + "public-objects";
 
     private static final String DEFAULT_OBJECTS_FOLDER = "/default-objects";
 

--- a/src/main/java/org/ow2/proactive/catalog/service/GroupsWithPrefixRetriever.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GroupsWithPrefixRetriever.java
@@ -25,36 +25,28 @@
  */
 package org.ow2.proactive.catalog.service;
 
-import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Component;
 
 
 /**
  * @author ActiveEon Team
- * @since 27/07/2017
+ * @since 07/08/2017
  */
 @Component
-public class AuthorizationService {
+public class GroupsWithPrefixRetriever {
 
-    public static final String GROUP_PREFIX = "GROUP:";
-
-    public boolean askUserAuthorizationByBucketOwner(AuthenticatedUser authenticatedUser, String bucketOwnerOrGroup) {
-        if (authenticatedUser == null) {
-            return false;
-        }
-        if (bucketOwnerOrGroup == null || bucketOwnerOrGroup == BucketService.DEFAULT_BUCKET_OWNER) {
-            return true;
-        }
-
-        String groupName = extractGroupFromBucketOwnerOrGroupString(bucketOwnerOrGroup);
-        return authenticatedUser.getGroups().contains(groupName) ||
-               BucketService.DEFAULT_BUCKET_OWNER.equals(groupName);
+    public List<String> getGroupsWithPrefixFromGroupList(List<String> groups) {
+        return groups.stream().map(this::addGroupPrefix).collect(Collectors.toList());
     }
 
-    private String extractGroupFromBucketOwnerOrGroupString(String bucketOwnerOrGroup) {
-        if (bucketOwnerOrGroup.startsWith(GROUP_PREFIX)) {
-            return bucketOwnerOrGroup.replace(GROUP_PREFIX, "");
-        }
-        return bucketOwnerOrGroup;
+    private String addGroupPrefix(String groupWithoutPrefix) {
+        return this.getGroupPrefix() + groupWithoutPrefix;
+    }
+
+    protected String getGroupPrefix() {
+        return AuthorizationService.GROUP_PREFIX;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,8 +47,8 @@ spring.main.banner_mode=off
 
 
 pa.scheduler.url=http://localhost:8080
-pa.scheduler.rest.url.postfix=/rest
-pa.catalog.rest.url=http://localhsot:8080/catalog
+# Used to perform authentication since identity service is not yet available
+pa.scheduler.rest.url=${pa.scheduler.url}/rest
 
 # Optional catalog security features
 pa.catalog.security.required.sessionid=false

--- a/src/test/java/org/ow2/proactive/catalog/service/AuthorizationServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/AuthorizationServiceTest.java
@@ -88,13 +88,13 @@ public class AuthorizationServiceTest {
     }
 
     @Test
-    public void testAgainstOwnerNullReturnsFalse() {
+    public void testAgainstOwnerNullReturnsTrueBecauseNoSpecificAccessRequired() {
         AuthenticatedUser authenticatedUser = AuthenticatedUser.builder()
                                                                .name("C3PO")
                                                                .groups(Arrays.asList("secret stuff", "robots"))
                                                                .build();
 
-        assertThat(authorizationService.askUserAuthorizationByBucketOwner(authenticatedUser, null)).isFalse();
+        assertThat(authorizationService.askUserAuthorizationByBucketOwner(authenticatedUser, null)).isTrue();
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/catalog/service/GroupsWithPrefixRetrieverTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/GroupsWithPrefixRetrieverTest.java
@@ -1,0 +1,70 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 08/08/2017
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GroupsWithPrefixRetrieverTest {
+
+    @InjectMocks
+    @Spy
+    GroupsWithPrefixRetriever groupsWithPrefixRetriever;
+
+    @Test(expected = NullPointerException.class)
+    public void testThatNullThrowsNullPointerException() {
+        groupsWithPrefixRetriever.getGroupsWithPrefixFromGroupList(null);
+    }
+
+    @Test
+    public void testThatEmptyListReturnsEmptyList() {
+        assertThat(groupsWithPrefixRetriever.getGroupsWithPrefixFromGroupList(Collections.EMPTY_LIST)).isEmpty();
+    }
+
+    @Test
+    public void testThatGroupPrefixIsAdded() {
+        when(groupsWithPrefixRetriever.getGroupPrefix()).thenReturn("PREFIX:");
+        List<String> result = groupsWithPrefixRetriever.getGroupsWithPrefixFromGroupList(Collections.singletonList("test"));
+        assertThat(result).contains("PREFIX:test");
+    }
+
+}


### PR DESCRIPTION
- The rest url was wrongly configured in the config, so resteasy threw an IllegalArguments Exception
- The GROUP: prefix must be added to the groups which come from the scheduler API. Because the owner is saved inside the DB with GROUP:{group}.
- The catalog is now populated instead of public-objects with GROUP:public-objects