### PR TITLE
Make generic information unique

### DIFF
--- a/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.spy;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
 import org.ow2.proactive.catalog.graphql.bean.argument.CatalogObjectWhereArgs;
 import org.ow2.proactive.catalog.graphql.fetcher.CatalogObjectFetcher;
 import org.ow2.proactive.catalog.graphql.handler.FilterHandler;
@@ -43,7 +42,7 @@ import org.ow2.proactive.catalog.service.BucketService;
 import org.ow2.proactive.catalog.service.CatalogObjectService;
 import org.ow2.proactive.catalog.service.GenericInformationAdder;
 import org.ow2.proactive.catalog.service.GraphqlService;
-import org.ow2.proactive.catalog.service.KeyValueMetadataHelper;
+import org.ow2.proactive.catalog.service.KeyValueLabelMetadataHelper;
 import org.ow2.proactive.catalog.service.OwnerGroupStringHelper;
 import org.ow2.proactive.catalog.service.WorkflowXmlManipulator;
 import org.ow2.proactive.catalog.util.ArchiveManagerHelper;
@@ -137,8 +136,8 @@ public class IntegrationTestConfig {
     }
 
     @Bean
-    public KeyValueMetadataHelper keyValueMetadataHelper() {
-        return new KeyValueMetadataHelper(new OwnerGroupStringHelper());
+    public KeyValueLabelMetadataHelper keyValueMetadataHelper() {
+        return new KeyValueLabelMetadataHelper(new OwnerGroupStringHelper());
     }
 
     @Bean

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -82,7 +82,7 @@ public class CatalogObjectService {
     private ArchiveManagerHelper archiveManager;
 
     @Autowired
-    private KeyValueMetadataHelper keyValueMetadataHelper;
+    private KeyValueLabelMetadataHelper keyValueLabelMetadataHelper;
 
     @Autowired
     private GenericInformationAdder genericInformationAdder;
@@ -152,18 +152,18 @@ public class CatalogObjectService {
     private CatalogObjectRevisionEntity buildCatalogObjectRevisionEntity(final String commitMessage,
             final List<Metadata> metadataList, final byte[] rawObject, final CatalogObjectEntity catalogObjectEntity) {
 
-        List<KeyValueLabelMetadataEntity> keyValueMetadataEntities = KeyValueMetadataHelper.convertToEntity(metadataList);
+        List<KeyValueLabelMetadataEntity> keyValueMetadataEntities = KeyValueLabelMetadataHelper.convertToEntity(metadataList);
 
-        List<KeyValueLabelMetadataEntity> keyValues = CollectionUtils.isEmpty(metadataList) ? keyValueMetadataHelper.extractKeyValuesFromRaw(catalogObjectEntity.getKind(),
-                                                                                                                                             rawObject)
+        List<KeyValueLabelMetadataEntity> keyValues = CollectionUtils.isEmpty(metadataList) ? keyValueLabelMetadataHelper.extractKeyValuesFromRaw(catalogObjectEntity.getKind(),
+                                                                                                                                                  rawObject)
                                                                                             : keyValueMetadataEntities;
 
         GenericInfoBucketData genericInfoBucketData = createGenericInfoBucketData(catalogObjectEntity.getBucket());
-        List<KeyValueLabelMetadataEntity> genericInformationWithBucketDataList = keyValueMetadataHelper.replaceMetadataRelatedGenericInfoAndKeepOthers(keyValues,
-                                                                                                                                                       genericInfoBucketData);
+        List<KeyValueLabelMetadataEntity> genericInformationWithBucketDataList = keyValueLabelMetadataHelper.replaceMetadataRelatedGenericInfoAndKeepOthers(keyValues,
+                                                                                                                                                            genericInfoBucketData);
         byte[] workflowWithReplacedGenericInfo = genericInformationAdder.addGenericInformationToRawObjectIfWorkflow(rawObject,
                                                                                                                     catalogObjectEntity.getKind(),
-                                                                                                                    keyValueMetadataHelper.toKeyValueEntry(genericInformationWithBucketDataList));
+                                                                                                                    keyValueLabelMetadataHelper.toMap(keyValueLabelMetadataHelper.getOnlyGenericInformation(genericInformationWithBucketDataList)));
 
         CatalogObjectRevisionEntity catalogObjectRevisionEntity = CatalogObjectRevisionEntity.builder()
                                                                                              .commitMessage(commitMessage)
@@ -312,7 +312,7 @@ public class CatalogObjectService {
         }
 
         CatalogObjectRevisionEntity restoredRevision = buildCatalogObjectRevisionEntity(catalogObjectRevision.getCommitMessage(),
-                                                                                        keyValueMetadataHelper.convertFromEntity(catalogObjectRevision.getKeyValueMetadataList()),
+                                                                                        keyValueLabelMetadataHelper.convertFromEntity(catalogObjectRevision.getKeyValueMetadataList()),
                                                                                         catalogObjectRevision.getRawObject(),
                                                                                         catalogObjectRevision.getCatalogObject());
 

--- a/src/main/java/org/ow2/proactive/catalog/service/GenericInformationAdder.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GenericInformationAdder.java
@@ -25,8 +25,7 @@
  */
 package org.ow2.proactive.catalog.service;
 
-import java.util.AbstractMap;
-import java.util.List;
+import java.util.Map;
 
 import org.ow2.proactive.catalog.util.parser.SupportedParserKinds;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,12 +44,11 @@ public class GenericInformationAdder {
     private WorkflowXmlManipulator workflowXmlManipulator;
 
     public byte[] addGenericInformationToRawObjectIfWorkflow(final byte[] rawObject,
-            final String catalogObjectEntityKind,
-            List<AbstractMap.SimpleImmutableEntry<String, String>> genericInformationMapEntry) {
+            final String catalogObjectEntityKind, Map<String, String> genericInformationMap) {
         byte[] workflowWithReplacedGenericInfo = rawObject;
         if (catalogObjectEntityKind.equals(SupportedParserKinds.WORKFLOW.toString())) {
             workflowWithReplacedGenericInfo = workflowXmlManipulator.replaceGenericInformation(rawObject,
-                                                                                               genericInformationMapEntry);
+                                                                                               genericInformationMap);
         }
         return workflowWithReplacedGenericInfo;
     }

--- a/src/main/java/org/ow2/proactive/catalog/service/WorkflowXmlManipulator.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/WorkflowXmlManipulator.java
@@ -25,8 +25,7 @@
  */
 package org.ow2.proactive.catalog.service;
 
-import java.util.AbstractMap;
-import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -70,24 +69,26 @@ public class WorkflowXmlManipulator {
         return genericInfoMatcher.replaceAll("").getBytes();
     }
 
-    public byte[] replaceGenericInformation(final byte[] xmlWorkflow,
-            List<AbstractMap.SimpleImmutableEntry<String, String>> genericInfoEntries) {
-        if (xmlWorkflow == null || genericInfoEntries == null) {
+    public byte[] replaceGenericInformation(final byte[] xmlWorkflow, Map<String, String> genericInfoMap) {
+        if (xmlWorkflow == null) {
             return new byte[] {};
+        }
+        if (genericInfoMap == null) {
+            return xmlWorkflow;
         }
 
         String workflowWithoutGenericInfo = new String(removeGenericInformation(xmlWorkflow));
 
         return taskFlowStartTagPattern.matcher(workflowWithoutGenericInfo)
                                       .replaceFirst(ONE_INTEND + GENERIC_INFORMATION_START_TAG + NEW_LINE +
-                                                    createGenericInfoString(genericInfoEntries) + ONE_INTEND +
+                                                    createGenericInfoString(genericInfoMap) + ONE_INTEND +
                                                     GENERIC_INFORMATION_END_TAG + NEW_LINE + TASK_FLOW_START_TAG)
                                       .getBytes();
     }
 
-    private String
-            createGenericInfoString(List<AbstractMap.SimpleImmutableEntry<String, String>> keyValueMetadataEntities) {
-        return keyValueMetadataEntities.stream()
+    private String createGenericInfoString(Map<String, String> keyValueMetadataEntities) {
+        return keyValueMetadataEntities.entrySet()
+                                       .stream()
                                        .map(entry -> String.format(GENERIC_INFORMATION_ENTRY_FORMAT_STRING,
                                                                    entry.getKey(),
                                                                    entry.getValue()))

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
@@ -85,7 +85,7 @@ public class CatalogObjectServiceTest {
     private BucketRepository bucketRepository;
 
     @Mock
-    private KeyValueMetadataHelper keyValueMetadataHelper;
+    private KeyValueLabelMetadataHelper keyValueLabelMetadataHelper;
 
     @Mock
     private GenericInformationAdder genericInformationAdder;
@@ -211,8 +211,8 @@ public class CatalogObjectServiceTest {
         when(catalogObjectRepository.findOne(any(CatalogObjectEntity.CatalogObjectEntityKey.class))).thenReturn(catalogObjectEntity);
         when(catalogObjectRevisionRepository.save(any(CatalogObjectRevisionEntity.class))).thenReturn(catalogObjectRevisionEntity);
         List<Metadata> keyvalues = ImmutableList.of(new Metadata("key", "value", null));
-        when(keyValueMetadataHelper.replaceMetadataRelatedGenericInfoAndKeepOthers(any(),
-                                                                                   any())).thenReturn(Collections.emptyList());
+        when(keyValueLabelMetadataHelper.replaceMetadataRelatedGenericInfoAndKeepOthers(any(),
+                                                                                        any())).thenReturn(Collections.emptyList());
         CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObjectRevision(1L,
                                                                                                NAME,
                                                                                                COMMIT_MESSAGE,

--- a/src/test/java/org/ow2/proactive/catalog/service/GenericInformationAdderTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/GenericInformationAdderTest.java
@@ -56,7 +56,7 @@ public class GenericInformationAdderTest {
     public void testThatWorkflowParserKindTriggersXmlManipulation() {
         genericInformationAdder.addGenericInformationToRawObjectIfWorkflow(new byte[] {},
                                                                            SupportedParserKinds.WORKFLOW.toString(),
-                                                                           Collections.emptyList());
+                                                                           Collections.emptyMap());
 
         verify(workflowXmlManipulator).replaceGenericInformation(Mockito.any(), Mockito.any());
     }
@@ -65,7 +65,7 @@ public class GenericInformationAdderTest {
     public void testThatOtherKindNotTriggersXmlManipulation() {
         genericInformationAdder.addGenericInformationToRawObjectIfWorkflow(new byte[] {},
                                                                            SupportedParserKinds.PCW_RULE.toString(),
-                                                                           Collections.emptyList());
+                                                                           Collections.emptyMap());
 
         verify(workflowXmlManipulator, times(0)).replaceGenericInformation(Mockito.any(), Mockito.any());
     }

--- a/src/test/java/org/ow2/proactive/catalog/service/WorkflowXmlManipulatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/WorkflowXmlManipulatorTest.java
@@ -27,10 +27,9 @@ package org.ow2.proactive.catalog.service;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -89,7 +88,7 @@ public class WorkflowXmlManipulatorTest {
     @Test
     public void testThatWorkflowHasGenericInfoTagAdded() {
         String emptyGenericInfo = new String(workflowXmlManipulator.replaceGenericInformation(simpleWorkflowWithoutGenericInfo,
-                                                                                              Collections.emptyList()));
+                                                                                              Collections.emptyMap()));
         assertThat(emptyGenericInfo).contains("<genericInformation>");
         assertThat(emptyGenericInfo).contains("</genericInformation>");
         assertThat(emptyGenericInfo).doesNotContain("<info name="); // Generic Info has no Entry
@@ -98,7 +97,7 @@ public class WorkflowXmlManipulatorTest {
     @Test
     public void testThatWorkflowHasGenericInfoRemovedIfAlreadyThere() {
         String emptyGenericInfo = new String(workflowXmlManipulator.replaceGenericInformation(simpleWorkflowWithGenericInfo,
-                                                                                              Collections.emptyList()));
+                                                                                              Collections.emptyMap()));
         assertThat(emptyGenericInfo).contains("<genericInformation>");
         assertThat(emptyGenericInfo).contains("</genericInformation>");
         assertThat(emptyGenericInfo).doesNotContain("<info name="); // Generic Info has no Entry
@@ -136,7 +135,7 @@ public class WorkflowXmlManipulatorTest {
 
     @Test
     public void testThatEmptyByteArrayIsReturnedIfXmlWorkflowIsNull() {
-        byte[] nullByteArray = workflowXmlManipulator.replaceGenericInformation(null, Collections.emptyList());
+        byte[] nullByteArray = workflowXmlManipulator.replaceGenericInformation(null, Collections.emptyMap());
         assertThat(nullByteArray.length).isEqualTo(0);
     }
 
@@ -146,11 +145,11 @@ public class WorkflowXmlManipulatorTest {
         assertThat(nullByteArray.length).isEqualTo(0);
     }
 
-    private List<AbstractMap.SimpleImmutableEntry<String, String>> getTwoSimpleEntries() {
-        List<AbstractMap.SimpleImmutableEntry<String, String>> returnList = new ArrayList<>();
+    private Map<String, String> getTwoSimpleEntries() {
+        Map<String, String> returnList = new HashMap<>();
 
-        returnList.add(new AbstractMap.SimpleImmutableEntry<>("firstTestKey", "firstTestValue"));
-        returnList.add(new AbstractMap.SimpleImmutableEntry<>("secondTestKey", "secondTestValue"));
+        returnList.put("firstTestKey", "firstTestValue");
+        returnList.put("secondTestKey", "secondTestValue");
 
         return returnList;
     }


### PR DESCRIPTION
Problem:
- Generic Information had double entries name and project_name

Solution:
- Changing the generic information to be unique through Map<>
- As a result name and project name are not added, because those values come as KeyValueLabelMetadata from the workflow parser. It needs some time to develop functionality which overwrites deterministically the generic information without managing each type separately. Since the name and project_name are not needed inside the generic info, it won't be included in this PR.
- Some minor renaming