### PR TITLE
Only add default owner to empty owner list

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
@@ -129,6 +129,7 @@ public class BucketController {
             if (ownerName == null) {
                 groups = ownerGroupStringHelper.getGroupsWithPrefixFromGroupList(restApiAccessResponse.getAuthenticatedUser()
                                                                                                       .getGroups());
+                groups.add(BucketService.DEFAULT_BUCKET_OWNER);
             } else {
                 groups = Collections.singletonList(ownerName);
             }

--- a/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
@@ -175,14 +175,11 @@ public class BucketService {
             return Collections.emptyList();
         }
 
-        List<String> ownersAndDefaultOwner = new ArrayList<>(owners);
-        ownersAndDefaultOwner.add(DEFAULT_BUCKET_OWNER);
-
         List<BucketEntity> entities;
         if (!StringUtils.isEmpty(kind)) {
-            entities = bucketRepository.findByOwnerIsInContainingKind(ownersAndDefaultOwner, kind);
+            entities = bucketRepository.findByOwnerIsInContainingKind(owners, kind);
         } else {
-            entities = bucketRepository.findByOwnerIn(ownersAndDefaultOwner);
+            entities = bucketRepository.findByOwnerIn(owners);
         }
 
         log.info("Buckets size {}", entities.size());

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketServiceTest.java
@@ -77,19 +77,6 @@ public class BucketServiceTest {
     private BucketRepository bucketRepository;
 
     @Test
-    public void testThatListBucketsAddsDefaultBucketOwner() {
-        bucketService.listBuckets(new ArrayList<>(), null);
-        verify(bucketRepository).findByOwnerIn(eq(Collections.singletonList(BucketService.DEFAULT_BUCKET_OWNER)));
-    }
-
-    @Test
-    public void testThatListBucketsAddsDefaultBucketOwnerWithKind() {
-        bucketService.listBuckets(new ArrayList<>(), "specialKind");
-        verify(bucketRepository).findByOwnerIsInContainingKind(eq(Collections.singletonList(BucketService.DEFAULT_BUCKET_OWNER)),
-                                                               eq("specialKind"));
-    }
-
-    @Test
     public void testThatEmptyListIsReturnedIfListAndKindAreNull() {
         assertThat(bucketService.listBuckets((List<String>) null, null)).isEmpty();
         verify(bucketRepository, times(0)).findByOwnerIsInContainingKind(any(), any());


### PR DESCRIPTION
Problem:
- listing all buckets for GROUP:admin lists all buckets for GROUP:public-objects and GROUP:admin. My expectation is that when I "search" for a specific owner, I get only buckets of that owner.

Solution:
- Add the default owner GROUP:public-objects only if the query did not specify any owner. So a query which has no owner specified will list all buckets visible for the user.