### PR TITLE
Scheduer Client Exceptions return 401 http status code

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/service/SchedulerUserAuthenticationService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/SchedulerUserAuthenticationService.java
@@ -50,9 +50,15 @@ public class SchedulerUserAuthenticationService {
     }
 
     public AuthenticatedUser authenticateBySessionId(String sessionId) throws NotAuthenticatedException {
-        UserData userData = this.schedulerRestClientCreator.getNewClientInitializedWithSchedulerRestUrl()
-                                                           .getScheduler()
-                                                           .getUserDataFromSessionId(sessionId);
+        UserData userData;
+        try {
+            userData = this.schedulerRestClientCreator.getNewClientInitializedWithSchedulerRestUrl()
+                                                      .getScheduler()
+                                                      .getUserDataFromSessionId(sessionId);
+        } catch (Exception exception) {
+            throw new NotAuthenticatedException("Could not validate sessionId, validation returned: " +
+                                                exception.getMessage());
+        }
 
         if (userData == null || StringUtils.isEmpty(userData.getUserName())) {
             throw new NotAuthenticatedException("SessionId is invalid");

--- a/src/test/java/org/ow2/proactive/catalog/service/SchedulerUserAuthenticationServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/SchedulerUserAuthenticationServiceTest.java
@@ -86,6 +86,13 @@ public class SchedulerUserAuthenticationServiceTest {
         schedulerUserAuthenticationService.authenticateBySessionId("any");
     }
 
+    @Test(expected = NotAuthenticatedException.class)
+    public void testAnyExceptionFromSchedulerRestClientThrowsNotAuthenticatedException()
+            throws NotAuthenticatedException {
+        when(schedulerRestInterfaceMock.getUserDataFromSessionId(any())).thenThrow(NullPointerException.class);
+        schedulerUserAuthenticationService.authenticateBySessionId("any");
+    }
+
     @Test
     public void testThatCorrectUsernameAndGroupAreInsideReturnObject() throws NotAuthenticatedException {
         AuthenticatedUser authenticatedUser = schedulerUserAuthenticationService.authenticateBySessionId("any");


### PR DESCRIPTION
Catch scheduler rest client's exceptions and throw internal

Problem:
- If the scheduler rest client throws any exception, it will be translated into the server error 500.

Solution:
- Catch any scheduler rest client exception and throw the not authenticated exception, which translates into an http status code of 401.