### PR TITLE
Prepend 'PA_' to KEY and VALUE columns to make it work with MySQL.

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/KeyValueLabelMetadataEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/KeyValueLabelMetadataEntity.java
@@ -58,9 +58,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Table(name = "METADATA_KEY_VALUE", uniqueConstraints = @UniqueConstraint(columnNames = { "CATALOGOBJECTREVISION",
-                                                                                          "KEY",
-                                                                                          "LABEL" }), indexes = { @Index(columnList = "KEY"),
-                                                                                                                  @Index(columnList = "VALUE") })
+                                                                                          "PA_KEY",
+                                                                                          "LABEL" }), indexes = { @Index(columnList = "PA_KEY"),
+                                                                                                                  @Index(columnList = "PA_VALUE") })
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 public class KeyValueLabelMetadataEntity implements Serializable {
 
@@ -72,10 +72,10 @@ public class KeyValueLabelMetadataEntity implements Serializable {
     @Column(name = "ID")
     protected Long id;
 
-    @Column(name = "KEY", nullable = false)
+    @Column(name = "PA_KEY", nullable = false)
     protected String key;
 
-    @Column(name = "VALUE", nullable = false)
+    @Column(name = "PA_VALUE", nullable = false)
     protected String value;
 
     @SuppressWarnings("DefaultAnnotationParam")


### PR DESCRIPTION
`KEY` is a reserved word in MySQL, this fixes #76.