### PR TITLE
fix #109 issue. Remove double decoding on server side. Fix link to raw object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The next example will fetch all Objects that has name like `Clear%` from `cloud-
 The response will return all fields, that are in the query.
 ```
 {
-  allCatalogObjects(where: {AND: [{nameArg: {like: “Clear%“}}, {bucketNameArg: {eq: "cloud-automation"}}]}) {
+  allCatalogObjects(where: {AND: [{nameArg: {like: "Clear%"}}, {bucketNameArg: {eq: "cloud-automation"}}]}) {
     edges {
       bucketName
       name

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -181,20 +181,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
     @Test
     public void testCreateWorkflowWithSpecificSymbolsInNameAndCheckReturnSavedWorkflow() throws IOException {
-        String objectNameWithSpecificSymbols = "workflow$with&specific&symbols in name:$&%ae";
-        //        String objectNameWithSpecificSymbols = "name 1";
-
+        String objectNameWithSpecificSymbols = "workflow$with&specific&symbols+in name:$&%ae";
         String encodedObjectName = URLEncoder.encode(objectNameWithSpecificSymbols, "UTF-8").replace("+", "%20");
-
-        String str = URLEncoder.encode(objectNameWithSpecificSymbols, "UTF-8");
-
-        byte[] myBytes = null;
-        try {
-            myBytes = str.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-            System.exit(-1);
-        }
 
         //create the workflow and check returned metadata
         given().urlEncodingEnabled(true)

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -33,8 +33,6 @@ import static org.hamcrest.Matchers.is;
 import static org.ow2.proactive.catalog.util.RawObjectResponseCreator.WORKFLOW_EXTENSION;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -163,20 +161,6 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("object[0].object_key_values[6].key", is("genericInfo2"))
                .body("object[0].object_key_values[6].value", is("genericInfo2Value"))
                .body("object[0].content_type", is(MediaType.APPLICATION_XML.toString()));
-    }
-
-    public static String decode(String url) {
-        try {
-            String prevURL = "";
-            String decodeURL = url;
-            while (!prevURL.equals(decodeURL)) {
-                prevURL = decodeURL;
-                decodeURL = URLDecoder.decode(decodeURL, "UTF-8");
-            }
-            return decodeURL;
-        } catch (UnsupportedEncodingException e) {
-            return "Issue while decoding" + e.getMessage();
-        }
     }
 
     @Test

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
@@ -32,6 +32,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -223,7 +225,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
     }
 
     @Test
-    public void testGetWorkflowRevisionShouldReturnSavedWorkflowRevision() {
+    public void testGetWorkflowRevisionShouldReturnSavedWorkflowRevision() throws UnsupportedEncodingException {
         ValidatableResponse validatableResponse = given().pathParam("bucketName", bucket.getName())
                                                          .pathParam("name", "WF_1_Rev_1")
                                                          .pathParam("commitTime",
@@ -277,7 +279,18 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
                            .body("object_key_values[7].value", is("var1ValueUpdated"))
                            .body("object_key_values[8].label", is("variable"))
                            .body("object_key_values[8].key", is("var2"))
-                           .body("object_key_values[8].value", is("var2ValueUpdated"));
+                           .body("object_key_values[8].value", is("var2ValueUpdated"))
+                           .body("_links.content.href",
+                                 containsString("/buckets/" + bucket.getName() + "/resources/" +
+                                                URLEncoder.encode(secondCatalogObjectRevision.get("name").toString(),
+                                                                  "UTF-8") +
+                                                "/revisions/" + secondCatalogObjectRevision.get("commit_time_raw") +
+                                                "/raw"))
+                           .body("_links.relative.href",
+                                 is("buckets/" + bucket.getName() + "/resources/" +
+                                    URLEncoder.encode(secondCatalogObjectRevision.get("name").toString(), "UTF-8") +
+                                    "/revisions/" + secondCatalogObjectRevision.get("commit_time_raw")));
+        ;
     }
 
     @Test

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
@@ -280,6 +280,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
                            .body("object_key_values[8].label", is("variable"))
                            .body("object_key_values[8].key", is("var2"))
                            .body("object_key_values[8].value", is("var2ValueUpdated"))
+                           //check link references
                            .body("_links.content.href",
                                  containsString("/buckets/" + bucket.getName() + "/resources/" +
                                                 URLEncoder.encode(secondCatalogObjectRevision.get("name").toString(),

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
@@ -242,6 +242,8 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
         System.out.println(responseString);
 
         System.out.println(secondCatalogObjectRevisionCommitTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        String encodedObjectName = URLEncoder.encode(secondCatalogObjectRevision.get("name").toString(), "UTF-8")
+                                             .replace("+", "%20");
 
         validatableResponse.statusCode(HttpStatus.SC_OK)
                            .body("bucket_name", is(secondCatalogObjectRevision.get("bucket_name")))
@@ -282,15 +284,12 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
                            .body("object_key_values[8].value", is("var2ValueUpdated"))
                            //check link references
                            .body("_links.content.href",
-                                 containsString("/buckets/" + bucket.getName() + "/resources/" +
-                                                URLEncoder.encode(secondCatalogObjectRevision.get("name").toString(),
-                                                                  "UTF-8") +
+                                 containsString("/buckets/" + bucket.getName() + "/resources/" + encodedObjectName +
                                                 "/revisions/" + secondCatalogObjectRevision.get("commit_time_raw") +
                                                 "/raw"))
                            .body("_links.relative.href",
-                                 is("buckets/" + bucket.getName() + "/resources/" +
-                                    URLEncoder.encode(secondCatalogObjectRevision.get("name").toString(), "UTF-8") +
-                                    "/revisions/" + secondCatalogObjectRevision.get("commit_time_raw")));
+                                 is("buckets/" + bucket.getName() + "/resources/" + encodedObjectName + "/revisions/" +
+                                    secondCatalogObjectRevision.get("commit_time_raw")));
         ;
     }
 

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -110,7 +110,6 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
         if (name.isPresent()) {
-            //            String decodedName = URLDecoder.decode(name.get(), "UTF-8");
             String objectName = name.get();
             CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObject(bucketName,
                                                                                            objectName,
@@ -149,8 +148,6 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        //        String decodedName = URLDecoder.decode(name, "UTF-8");
-
         CatalogObjectMetadata metadata = catalogObjectService.getCatalogObjectMetadata(bucketName, name);
         metadata.add(LinkUtil.createLink(bucketName, metadata.getName()));
         metadata.add(LinkUtil.createRelativeLink(bucketName, metadata.getName()));
@@ -172,10 +169,7 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        //        String decodedName = URLDecoder.decode(name, "UTF-8");
-
         CatalogRawObject rawObject = catalogObjectService.getCatalogRawObject(bucketName, name);
-
         return rawObjectResponseCreator.createRawObjectResponse(rawObject);
 
     }
@@ -199,13 +193,6 @@ public class CatalogObjectController {
         }
 
         if (names.isPresent()) {
-            //            List<String> decodedNames = names.get().stream().map(name -> {
-            //                try {
-            //                    return URLDecoder.decode(name, "UTF-8");
-            //                } catch (UnsupportedEncodingException e) {
-            //                    return name;
-            //                }
-            //            }).collect(Collectors.toList());
 
             ZipArchiveContent zipArchiveContent = catalogObjectService.getCatalogObjectsAsZipArchive(bucketName,
                                                                                                      names.get());
@@ -259,8 +246,6 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        //        String decodedName = URLDecoder.decode(name, "UTF-8");
-
         catalogObjectService.delete(bucketName, name);
 
         return new ResponseEntity<>(HttpStatus.OK);
@@ -279,7 +264,6 @@ public class CatalogObjectController {
         if (sessionIdRequired) {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
-        //        String decodedName = URLDecoder.decode(name, "UTF-8");
 
         CatalogObjectMetadata catalogObjectMetadata = catalogObjectService.restore(bucketName, name, commitTimeRaw);
         return ResponseEntity.ok(catalogObjectMetadata);

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -110,9 +110,8 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
         if (name.isPresent()) {
-            String objectName = name.get();
             CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObject(bucketName,
-                                                                                           objectName,
+                                                                                           name.get(),
                                                                                            kind,
                                                                                            commitMessage,
                                                                                            objectContentType,

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -33,10 +33,8 @@ import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URLDecoder;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -112,8 +110,10 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
         if (name.isPresent()) {
+            //            String decodedName = URLDecoder.decode(name.get(), "UTF-8");
+            String objectName = name.get();
             CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObject(bucketName,
-                                                                                           name.get(),
+                                                                                           objectName,
                                                                                            kind,
                                                                                            commitMessage,
                                                                                            objectContentType,
@@ -149,9 +149,9 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        String decodedName = URLDecoder.decode(name, "UTF-8");
+        //        String decodedName = URLDecoder.decode(name, "UTF-8");
 
-        CatalogObjectMetadata metadata = catalogObjectService.getCatalogObjectMetadata(bucketName, decodedName);
+        CatalogObjectMetadata metadata = catalogObjectService.getCatalogObjectMetadata(bucketName, name);
         metadata.add(LinkUtil.createLink(bucketName, metadata.getName()));
         metadata.add(LinkUtil.createRelativeLink(bucketName, metadata.getName()));
         return ResponseEntity.ok(metadata);
@@ -172,9 +172,9 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        String decodedName = URLDecoder.decode(name, "UTF-8");
+        //        String decodedName = URLDecoder.decode(name, "UTF-8");
 
-        CatalogRawObject rawObject = catalogObjectService.getCatalogRawObject(bucketName, decodedName);
+        CatalogRawObject rawObject = catalogObjectService.getCatalogRawObject(bucketName, name);
 
         return rawObjectResponseCreator.createRawObjectResponse(rawObject);
 
@@ -199,16 +199,17 @@ public class CatalogObjectController {
         }
 
         if (names.isPresent()) {
-            List<String> decodedNames = names.get().stream().map(name -> {
-                try {
-                    return URLDecoder.decode(name, "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    return name;
-                }
-            }).collect(Collectors.toList());
+            //            List<String> decodedNames = names.get().stream().map(name -> {
+            //                try {
+            //                    return URLDecoder.decode(name, "UTF-8");
+            //                } catch (UnsupportedEncodingException e) {
+            //                    return name;
+            //                }
+            //            }).collect(Collectors.toList());
 
             ZipArchiveContent zipArchiveContent = catalogObjectService.getCatalogObjectsAsZipArchive(bucketName,
-                                                                                                     decodedNames);
+                                                                                                     names.get());
+            ;
 
             HttpStatus status;
             if (zipArchiveContent.isPartial()) {
@@ -259,9 +260,9 @@ public class CatalogObjectController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        String decodedName = URLDecoder.decode(name, "UTF-8");
+        //        String decodedName = URLDecoder.decode(name, "UTF-8");
 
-        catalogObjectService.delete(bucketName, decodedName);
+        catalogObjectService.delete(bucketName, name);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
@@ -279,11 +280,9 @@ public class CatalogObjectController {
         if (sessionIdRequired) {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
-        String decodedName = URLDecoder.decode(name, "UTF-8");
+        //        String decodedName = URLDecoder.decode(name, "UTF-8");
 
-        CatalogObjectMetadata catalogObjectMetadata = catalogObjectService.restore(bucketName,
-                                                                                   decodedName,
-                                                                                   commitTimeRaw);
+        CatalogObjectMetadata catalogObjectMetadata = catalogObjectService.restore(bucketName, name, commitTimeRaw);
         return ResponseEntity.ok(catalogObjectMetadata);
 
     }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -209,7 +209,6 @@ public class CatalogObjectController {
 
             ZipArchiveContent zipArchiveContent = catalogObjectService.getCatalogObjectsAsZipArchive(bucketName,
                                                                                                      names.get());
-            ;
 
             HttpStatus status;
             if (zipArchiveContent.isPartial()) {

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
@@ -30,7 +30,6 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.List;
 
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
@@ -98,7 +97,7 @@ public class CatalogObjectRevisionController {
         if (sessionIdRequired) {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
-
+        //        String decodedName = URLDecoder.decode(name, "UTF-8");
         CatalogObjectMetadata catalogObjectRevision = catalogObjectService.createCatalogObjectRevision(bucketName,
                                                                                                        name,
                                                                                                        commitMessage,
@@ -122,10 +121,8 @@ public class CatalogObjectRevisionController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        String decodedName = URLDecoder.decode(name, "UTF-8");
-        CatalogObjectMetadata metadata = catalogObjectService.getCatalogObjectRevision(bucketName,
-                                                                                       decodedName,
-                                                                                       commitTimeRaw);
+        //        String decodedName = URLDecoder.decode(name, "UTF-8");
+        CatalogObjectMetadata metadata = catalogObjectService.getCatalogObjectRevision(bucketName, name, commitTimeRaw);
         metadata.add(LinkUtil.createLink(bucketName, metadata.getName(), metadata.getCommitDateTime()));
         metadata.add(LinkUtil.createRelativeLink(bucketName, metadata.getName(), metadata.getCommitDateTime()));
         return ResponseEntity.ok(metadata);
@@ -146,9 +143,9 @@ public class CatalogObjectRevisionController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        String decodedName = URLDecoder.decode(name, "UTF-8");
+        //        String decodedName = URLDecoder.decode(name, "UTF-8");
         CatalogRawObject objectRevisionRaw = catalogObjectService.getCatalogObjectRevisionRaw(bucketName,
-                                                                                              decodedName,
+                                                                                              name,
                                                                                               commitTimeRaw);
 
         return rawObjectResponseCreator.createRawObjectResponse(objectRevisionRaw);
@@ -167,9 +164,9 @@ public class CatalogObjectRevisionController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        String decodedName = URLDecoder.decode(name, "UTF-8");
+        //        String decodedName = URLDecoder.decode(name, "UTF-8");
         List<CatalogObjectMetadata> catalogObjectMetadataList = catalogObjectService.listCatalogObjectRevisions(bucketName,
-                                                                                                                decodedName);
+                                                                                                                name);
 
         for (CatalogObjectMetadata catalogObjectMetadata : catalogObjectMetadataList) {
             catalogObjectMetadata.add(LinkUtil.createLink(bucketName,

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
@@ -97,7 +97,6 @@ public class CatalogObjectRevisionController {
         if (sessionIdRequired) {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
-        //        String decodedName = URLDecoder.decode(name, "UTF-8");
         CatalogObjectMetadata catalogObjectRevision = catalogObjectService.createCatalogObjectRevision(bucketName,
                                                                                                        name,
                                                                                                        commitMessage,
@@ -121,7 +120,6 @@ public class CatalogObjectRevisionController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        //        String decodedName = URLDecoder.decode(name, "UTF-8");
         CatalogObjectMetadata metadata = catalogObjectService.getCatalogObjectRevision(bucketName, name, commitTimeRaw);
         metadata.add(LinkUtil.createLink(bucketName, metadata.getName(), metadata.getCommitDateTime()));
         metadata.add(LinkUtil.createRelativeLink(bucketName, metadata.getName(), metadata.getCommitDateTime()));
@@ -143,7 +141,6 @@ public class CatalogObjectRevisionController {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
 
-        //        String decodedName = URLDecoder.decode(name, "UTF-8");
         CatalogRawObject objectRevisionRaw = catalogObjectService.getCatalogObjectRevisionRaw(bucketName,
                                                                                               name,
                                                                                               commitTimeRaw);
@@ -163,8 +160,6 @@ public class CatalogObjectRevisionController {
         if (sessionIdRequired) {
             restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionId, bucketName);
         }
-
-        //        String decodedName = URLDecoder.decode(name, "UTF-8");
         List<CatalogObjectMetadata> catalogObjectMetadataList = catalogObjectService.listCatalogObjectRevisions(bucketName,
                                                                                                                 name);
 

--- a/src/main/java/org/ow2/proactive/catalog/util/LinkUtil.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/LinkUtil.java
@@ -73,7 +73,9 @@ public class LinkUtil {
             String absoluteLink = linkTo(methodOn(CatalogObjectRevisionController.class).getRaw(null,
                                                                                                 bucketName,
                                                                                                 URLEncoder.encode(name,
-                                                                                                                  "UTF-8"),
+                                                                                                                  "UTF-8")
+                                                                                                          .replace("+",
+                                                                                                                   "%20"),
                                                                                                 epochMilli));
 
             return new Link(absoluteLink).withRel("content");
@@ -99,8 +101,25 @@ public class LinkUtil {
             //                                                                                                                                  "UTF-8")));
             String absoluteLink = linkTo(methodOn(CatalogObjectController.class).getRaw(null,
                                                                                         bucketName,
-                                                                                        URLEncoder.encode(name,
-                                                                                                          "UTF-8")));
+                                                                                        URLEncoder.encode(name, "UTF-8")
+                                                                                                  .replace("+",
+                                                                                                           "%20")));
+
+            String relativeStr = UriComponentsBuilder.fromUriString(linkTo(methodOn(CatalogObjectController.class).getRaw(null,
+                                                                                                                          bucketName,
+                                                                                                                          name)))
+                                                     .scheme(null)
+                                                     .host(null)
+                                                     .build()
+                                                     .toUriString();
+
+            String absoluteStr = UriComponentsBuilder.fromUriString(linkTo(methodOn(CatalogObjectController.class).getRaw(null,
+                                                                                                                          bucketName,
+                                                                                                                          name)))
+                                                     .build()
+                                                     .toUriString();
+
+            String absoluteLink2 = linkTo(methodOn(CatalogObjectController.class).getRaw(null, bucketName, name));
 
             return new Link(absoluteLink).withRel("content");
         } catch (UnsupportedEncodingException e) {
@@ -122,8 +141,9 @@ public class LinkUtil {
         Link link = null;
         try {
             long epochMilli = commitTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-            link = new Link("buckets/" + bucketName + "/resources/" + URLEncoder.encode(objectName, "UTF-8") +
-                            "/revisions/" + epochMilli).withRel("relative");
+            link = new Link("buckets/" + bucketName + "/resources/" +
+                            URLEncoder.encode(objectName, "UTF-8").replace("+", "%20") + "/revisions/" +
+                            epochMilli).withRel("relative");
 
         } catch (UnsupportedEncodingException e) {
             log.error("{} cannot be encoded", objectName, e);
@@ -143,7 +163,7 @@ public class LinkUtil {
         Link link = null;
         try {
             link = new Link("buckets/" + bucketName + "/resources/" +
-                            URLEncoder.encode(objectName, "UTF-8")).withRel("relative");
+                            URLEncoder.encode(objectName, "UTF-8").replace("+", "%20")).withRel("relative");
 
         } catch (UnsupportedEncodingException e) {
             log.error("{} cannot be encoded", objectName, e);

--- a/src/main/java/org/ow2/proactive/catalog/util/LinkUtil.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/LinkUtil.java
@@ -66,10 +66,7 @@ public class LinkUtil {
             long epochMilli = commitTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
             String absoluteLink = linkTo(methodOn(CatalogObjectRevisionController.class).getRaw(null,
                                                                                                 bucketName,
-                                                                                                URLEncoder.encode(name,
-                                                                                                                  "UTF-8")
-                                                                                                          .replace("+",
-                                                                                                                   "%20"),
+                                                                                                encodeUrl(name),
                                                                                                 epochMilli));
 
             return new Link(absoluteLink).withRel("content");
@@ -156,7 +153,7 @@ public class LinkUtil {
     }
 
     /**
-     * Method is craeted to avoid double encoding
+     * Method is created to avoid double encoding
      * @param invocationValue
      * @return encoded link
      */
@@ -170,9 +167,9 @@ public class LinkUtil {
     }
 
     /**
-     * The aim of this method to encode the specified value, so it can be decoded in the same way for Spring: @PathVariable and @RequestParam
+     * The aim of this method to encode the specified value, so it can be decoded in the same way for Spring annotations: PathVariable and RequestParam
      * According to specification:
-     * '+' is accepted by @RequestParam as space. In case of @PathVariable, '+' is accepted as '+'
+     * '+' is accepted by RequestParam as space. In case of PathVariable, '+' is accepted as '+'
      * @param valueToEncode
      * @return the encoded string that will be compliant with REST API requests
      * @throws UnsupportedEncodingException


### PR DESCRIPTION
fix #109 issue. There is two parts of contribution.
Firs: remove double decoding on server side for all parameters for CatalogObject Controllers for all REST API requests, as Spring already decode all parameters. Double decoding was causing the user-not expecting transformation of ObjectName parameter.
Second: the link to raw object provided in response metadata was not correct for special symbols.
The double encoding inside link was solved. The space is correctly encoded in link. So the raw object can be correctly retrieved by specified link

This behavior is checked with a created specific test.