### PR TITLE
Save file extension as metadata

### DIFF
--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -190,49 +190,39 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
         // Add an object of kind "workflow" into first bucket
         // The object with same kind should be already present in catalog
         given().pathParam("bucketName", bucket.getName())
-                .queryParam("kind", "workflow")
-                .queryParam("name", "new workflow")
-                .queryParam("commitMessage", "commit message")
-                .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
-                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
-                .when()
-                .post(CATALOG_OBJECTS_RESOURCE)
-                .then()
-                .statusCode(HttpStatus.SC_CREATED);
+               .queryParam("kind", "workflow")
+               .queryParam("name", "new workflow")
+               .queryParam("commitMessage", "commit message")
+               .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
+               .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
+               .when()
+               .post(CATALOG_OBJECTS_RESOURCE)
+               .then()
+               .statusCode(HttpStatus.SC_CREATED);
 
         List<String> allKinds = new ArrayList<>();
         allKinds.add("workflow");
-        given().when()
-                .get("/kinds")
-                .then()
-                .assertThat()
-                .statusCode(HttpStatus.SC_OK)
-                .body("", is(allKinds));
+        given().when().get("/kinds").then().assertThat().statusCode(HttpStatus.SC_OK).body("", is(allKinds));
 
         String otherKind = "workflow new kind";
         given().pathParam("bucketName", bucket.getName())
-                .queryParam("kind", otherKind)
-                .queryParam("name", "new object")
-                .queryParam("commitMessage", "commit message")
-                .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
-                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
-                .when()
-                .post(CATALOG_OBJECTS_RESOURCE)
-                .then()
-                .statusCode(HttpStatus.SC_CREATED);
+               .queryParam("kind", otherKind)
+               .queryParam("name", "new object")
+               .queryParam("commitMessage", "commit message")
+               .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
+               .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
+               .when()
+               .post(CATALOG_OBJECTS_RESOURCE)
+               .then()
+               .statusCode(HttpStatus.SC_CREATED);
 
         allKinds.add(otherKind);
-        given().when()
-                .get("/kinds")
-                .then()
-                .assertThat()
-                .statusCode(HttpStatus.SC_OK)
-                .body("", is(allKinds));
+        given().when().get("/kinds").then().assertThat().statusCode(HttpStatus.SC_OK).body("", is(allKinds));
     }
 
     @Test
     public void testCreateWorkflowWithSpecificSymbolsInNameAndCheckReturnSavedWorkflow() throws IOException {
-        String objectNameWithSpecificSymbols = "workflow$with&specific&symbols+in name:$&%ae";
+        String objectNameWithSpecificSymbols = "workflow$with&specific&symbols+in name:$&%ae.extension";
         String encodedObjectName = URLEncoder.encode(objectNameWithSpecificSymbols, "UTF-8")
                                              .replace(SPACE_ENCODED_AS_PLUS, SPACE_ENCODED_AS_PERCENT_20);
 

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -130,6 +130,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("object[0].bucket_name", is(bucket.getName()))
                .body("object[0].kind", is("Workflow/specific-workflow-kind"))
                .body("object[0].name", is("workflow_test"))
+               .body("object[0].extension", is("xml"))
 
                .body("object[0].object_key_values", hasSize(9))
                //check job info
@@ -174,7 +175,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .statusCode(HttpStatus.SC_OK)
                .body("bucket_name", is(bucket.getName()))
                .body("kind", is("updated-kind"))
-               .body("content_type", is("updated-contentType"));
+               .body("content_type", is("updated-contentType"))
+               .body("extension", is("xml"));
 
         given().pathParam("bucketName", bucket.getName())
                .pathParam("name", "workflowname")
@@ -281,6 +283,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("object[0].bucket_name", is(bucket.getName()))
                .body("object[0].kind", is("workflow/specific-workflow-kind"))
                .body("object[0].name", is(objectNameWithSpecificSymbols))
+               .body("object[0].extension", is("xml"))
 
                .body("object[0].object_key_values", hasSize(9))
                //check job info
@@ -349,12 +352,13 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
     @Test
     public void testCreatePCWRuleShouldReturnSavedRule() throws IOException {
         String ruleName = "pcw-rule test.rule";
+        String fileExtension = "json";
         given().pathParam("bucketName", bucket.getName())
                .queryParam("kind", "Rule/cpu")
                .queryParam("name", ruleName)
                .queryParam("commitMessage", "first commit")
                .queryParam("objectContentType", MediaType.APPLICATION_JSON_VALUE)
-               .multiPart(IntegrationTestUtil.getPCWRule("pcwRuleExample.json"))
+               .multiPart(IntegrationTestUtil.getPCWRule("pcwRuleExample." + fileExtension))
                .when()
                .post(CATALOG_OBJECTS_RESOURCE)
                .then()
@@ -363,6 +367,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("object[0].bucket_name", is(bucket.getName()))
                .body("object[0].kind", is("Rule/cpu"))
                .body("object[0].name", is(ruleName))
+               .body("object[0].extension", is(fileExtension))
 
                .body("object[0].object_key_values", hasSize(8))
                //check pcw metadata info
@@ -398,7 +403,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                       ByteStreams.toByteArray(new FileInputStream(IntegrationTestUtil.getPCWRule("pcwRuleExample.json"))));
         rawResponse.then().assertThat().statusCode(HttpStatus.SC_OK).contentType(MediaType.APPLICATION_JSON.toString());
         rawResponse.then().assertThat().header(HttpHeaders.CONTENT_DISPOSITION,
-                                               is("attachment; filename=\"" + ruleName + "\""));
+                                               is("attachment; filename=\"" + ruleName + "." + fileExtension + "\""));
         rawResponse.then().assertThat().header(HttpHeaders.CONTENT_TYPE,
                                                is(MediaType.APPLICATION_JSON.toString() + ";charset=UTF-8"));
     }
@@ -745,7 +750,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .assertThat()
                .statusCode(HttpStatus.SC_OK)
                .body("commit_message", is(firstCommitMessage))
-               .body("content_type", is(MediaType.APPLICATION_XML.toString()));
+               .body("content_type", is(MediaType.APPLICATION_XML.toString()))
+               .body("extension", is("xml"));
 
         //Check that workflow_new has no revisions
         given().pathParam("bucketName", bucket.getName())
@@ -777,7 +783,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .assertThat()
                .statusCode(HttpStatus.SC_OK)
                .body("commit_message", is(archiveCommitMessage))
-               .body("content_type", is(MediaType.APPLICATION_XML.toString()));
+               .body("content_type", is(MediaType.APPLICATION_XML.toString()))
+               .body("extension", is("xml"));
 
         //Check that workflow_new was created
         given().pathParam("bucketName", bucket.getName())
@@ -788,7 +795,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .assertThat()
                .statusCode(HttpStatus.SC_OK)
                .body("commit_message", is(archiveCommitMessage))
-               .body("content_type", is(MediaType.APPLICATION_XML.toString()));
+               .body("content_type", is(MediaType.APPLICATION_XML.toString()))
+               .body("extension", is("xml"));
     }
 
     @Test
@@ -817,7 +825,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .assertThat()
                .statusCode(HttpStatus.SC_OK)
                .body("commit_message", is(archiveCommitMessage))
-               .body("content_type", is("application/x-bat"));
+               .body("content_type", is("application/x-bat"))
+               .body("extension", is("bat"));
 
         //Check that the object was created
         given().pathParam("bucketName", bucket.getName())
@@ -828,7 +837,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .assertThat()
                .statusCode(HttpStatus.SC_OK)
                .body("commit_message", is(archiveCommitMessage))
-               .body("content_type", is(MediaType.APPLICATION_JSON_VALUE));
+               .body("content_type", is(MediaType.APPLICATION_JSON_VALUE))
+               .body("extension", is("json"));
     }
 
     @Test

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -386,8 +386,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("object[0].object_key_values[5].key", is("NodeUrls"))
                .body("object[0].object_key_values[5].value",
                      is("[\"localhost\",\"service:jmx:rmi:///jndi/rmi://192.168.1.122:52304/rmnode\"]"))
-               .body("object[0].content_type", is(MediaType.APPLICATION_JSON_VALUE))
-               .header(HttpHeaders.CONTENT_DISPOSITION, is("attachment; filename=\"" + ruleName + "\""));
+               .body("object[0].content_type", is(MediaType.APPLICATION_JSON_VALUE));
 
         //check get the raw object, created on previous request with specific name
         Response rawResponse = given().urlEncodingEnabled(true)
@@ -396,12 +395,10 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                                       .when()
                                       .get(CATALOG_OBJECT_RESOURCE + "/raw");
         Arrays.equals(ByteStreams.toByteArray(rawResponse.asInputStream()),
-                ByteStreams.toByteArray(new FileInputStream(IntegrationTestUtil.getPCWRule("pcwRuleExample.json"))));
+                      ByteStreams.toByteArray(new FileInputStream(IntegrationTestUtil.getPCWRule("pcwRuleExample.json"))));
         rawResponse.then().assertThat().statusCode(HttpStatus.SC_OK).contentType(MediaType.APPLICATION_JSON.toString());
-        rawResponse.then()
-                   .assertThat()
-                   .header(HttpHeaders.CONTENT_DISPOSITION,
-                           is("attachment; filename=\"" + ruleName + "\""));
+        rawResponse.then().assertThat().header(HttpHeaders.CONTENT_DISPOSITION,
+                                               is("attachment; filename=\"" + ruleName + "\""));
         rawResponse.then().assertThat().header(HttpHeaders.CONTENT_TYPE,
                                                is(MediaType.APPLICATION_JSON.toString() + ";charset=UTF-8"));
     }
@@ -729,7 +726,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
         //Create a workflow with the bucketName of a workflow of the archive
         given().pathParam("bucketName", bucket.getName())
                .queryParam("kind", "workflow")
-               .queryParam("name", "workflow_existing")
+               .queryParam("name", "workflow_existing.xml")
                .queryParam("commitMessage", firstCommitMessage)
                .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
                .multiPart(IntegrationTestUtil.getArchiveFile("workflow_0.xml"))
@@ -741,7 +738,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that workflow_existing has a a first revision
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflow_existing")
+               .pathParam("name", "workflow_existing.xml")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -752,7 +749,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that workflow_new has no revisions
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflow_new")
+               .pathParam("name", "workflow_new.xml")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -773,7 +770,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that workflow_existing has a new revision
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflow_existing")
+               .pathParam("name", "workflow_existing.xml")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -784,7 +781,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that workflow_new was created
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflow_new")
+               .pathParam("name", "workflow_new.xml")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -813,7 +810,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that the object was created
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "cmdFile")
+               .pathParam("name", "cmdFile.bat")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -824,7 +821,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that the object was created
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "array")
+               .pathParam("name", "array.json")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -98,7 +98,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
         // Add an object of kind "workflow" into first bucket
         given().pathParam("bucketName", bucket.getName())
                .queryParam("kind", "workflow")
-               .queryParam("name", "workflowname.xml")
+               .queryParam("name", "workflowname")
                .queryParam("commitMessage", "commit message")
                .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
@@ -164,7 +164,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
     @Test
     public void testUpdateObjectMetadataAndGetItSavedObjectFromCatalog() {
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflowname.xml")
+               .pathParam("name", "workflowname")
                .queryParam("kind", "updated-kind")
                .queryParam("contentType", "updated-contentType")
                .when()
@@ -177,7 +177,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("content_type", is("updated-contentType"));
 
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflowname.xml")
+               .pathParam("name", "workflowname")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -407,7 +407,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
     public void testCreateObjectAlreadyExisting() {
         given().pathParam("bucketName", bucket.getName())
                .queryParam("kind", "workflow")
-               .queryParam("name", "workflowname.xml")
+               .queryParam("name", "workflowname")
                .queryParam("commitMessage", "commit message")
                .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
@@ -417,7 +417,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .statusCode(HttpStatus.SC_CONFLICT)
                .body(ERROR_MESSAGE,
                      equalTo(new CatalogObjectAlreadyExistingException(bucket.getName(),
-                                                                       "workflowname.xml").getLocalizedMessage()));
+                                                                       "workflowname").getLocalizedMessage()));
     }
 
     @Test
@@ -465,7 +465,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
     public void testGetWorkflowShouldReturnLatestSavedWorkflowRevision() throws IOException {
 
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflowname.xml")
+               .pathParam("name", "workflowname")
                .queryParam("commitMessage", "commit message2")
                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
                .when()
@@ -474,7 +474,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .statusCode(HttpStatus.SC_CREATED);
 
         HashMap<String, Object> thirdWFRevision = given().pathParam("bucketName", bucket.getName())
-                                                         .pathParam("name", "workflowname.xml")
+                                                         .pathParam("name", "workflowname")
                                                          .queryParam("commitMessage", "commit message3")
                                                          .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
                                                          .when()
@@ -485,7 +485,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                                                          .path("");
 
         ValidatableResponse response = given().pathParam("bucketName", bucket.getName())
-                                              .pathParam("name", "workflowname.xml")
+                                              .pathParam("name", "workflowname")
                                               .when()
                                               .get(CATALOG_OBJECT_RESOURCE)
                                               .then()
@@ -534,7 +534,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
     @Test
     public void testGetRawWorkflowShouldReturnSavedRawObject() throws IOException {
         Response response = given().pathParam("bucketName", bucket.getName())
-                                   .pathParam("name", "workflowname.xml")
+                                   .pathParam("name", "workflowname")
                                    .when()
                                    .get(CATALOG_OBJECT_RESOURCE + "/raw");
 
@@ -624,7 +624,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
     @Test
     public void testDeleteExistingObject() {
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflowname.xml")
+               .pathParam("name", "workflowname")
                .when()
                .delete(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -633,7 +633,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         // check that the object is really gone
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflowname.xml")
+               .pathParam("name", "workflowname")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -641,7 +641,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .statusCode(HttpStatus.SC_NOT_FOUND)
                .body(ERROR_MESSAGE,
                      equalTo(new CatalogObjectNotFoundException(bucket.getName(),
-                                                                "workflowname.xml").getLocalizedMessage()));
+                                                                "workflowname").getLocalizedMessage()));
     }
 
     @Test
@@ -675,7 +675,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         given().pathParam("bucketName", bucket.getName())
                .when()
-               .get(CATALOG_OBJECTS_RESOURCE + "?name=workflowname.xml,workflowname2")
+               .get(CATALOG_OBJECTS_RESOURCE + "?name=workflowname,workflowname2")
                .then()
                .assertThat()
                .statusCode(HttpStatus.SC_OK)
@@ -700,7 +700,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
         //get zip file for workflow name's list separated by coma
         given().pathParam("bucketName", bucket.getName())
                .when()
-               .get(CATALOG_OBJECTS_RESOURCE + "?name=workflowname.xml," + nameWithSpecialSymbols)
+               .get(CATALOG_OBJECTS_RESOURCE + "?name=workflowname," + nameWithSpecialSymbols)
                .then()
                .assertThat()
                .statusCode(HttpStatus.SC_OK)
@@ -726,7 +726,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
         //Create a workflow with the bucketName of a workflow of the archive
         given().pathParam("bucketName", bucket.getName())
                .queryParam("kind", "workflow")
-               .queryParam("name", "workflow_existing.xml")
+               .queryParam("name", "workflow_existing")
                .queryParam("commitMessage", firstCommitMessage)
                .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
                .multiPart(IntegrationTestUtil.getArchiveFile("workflow_0.xml"))
@@ -738,7 +738,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that workflow_existing has a a first revision
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflow_existing.xml")
+               .pathParam("name", "workflow_existing")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -749,7 +749,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that workflow_new has no revisions
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflow_new.xml")
+               .pathParam("name", "workflow_new")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -770,7 +770,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that workflow_existing has a new revision
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflow_existing.xml")
+               .pathParam("name", "workflow_existing")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -781,7 +781,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that workflow_new was created
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "workflow_new.xml")
+               .pathParam("name", "workflow_new")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -810,7 +810,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that the object was created
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "cmdFile.bat")
+               .pathParam("name", "cmdFile")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()
@@ -821,7 +821,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
 
         //Check that the object was created
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "array.json")
+               .pathParam("name", "array")
                .when()
                .get(CATALOG_OBJECT_RESOURCE)
                .then()

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
@@ -107,7 +107,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
         // Add an object of kind "workflow" into first bucket
         catalogObjectRevisionAlone = given().pathParam("bucketName", bucket.getName())
                                             .queryParam("kind", "workflow")
-                                            .queryParam("name", "WF_1_Rev_1")
+                                            .queryParam("name", "WF_1_Rev_1.xml")
                                             .queryParam("commitMessage", "alone commit")
                                             .queryParam("objectContentType", objectContentType)
                                             .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
@@ -120,7 +120,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
 
         Thread.sleep(SLEEP_TIME);
         firstCatalogObjectRevision = given().pathParam("bucketName", bucket.getName())
-                                            .pathParam("name", "WF_1_Rev_1")
+                                            .pathParam("name", "WF_1_Rev_1.xml")
                                             .queryParam("commitMessage", "first commit")
                                             .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
                                             .when()
@@ -132,7 +132,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
 
         Thread.sleep(SLEEP_TIME);
         secondCatalogObjectRevision = given().pathParam("bucketName", bucket.getName())
-                                             .pathParam("name", "WF_1_Rev_1")
+                                             .pathParam("name", "WF_1_Rev_1.xml")
                                              .queryParam("commitMessage", "second commit")
                                              .multiPart(IntegrationTestUtil.getWorkflowFile("workflow-updated.xml"))
                                              .when()
@@ -156,7 +156,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
     public void testCreateWorkflowRevisionShouldReturnSavedWorkflow() {
 
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "WF_1_Rev_1")
+               .pathParam("name", "WF_1_Rev_1.xml")
                .queryParam("commitMessage", "first commit")
                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
                .when()
@@ -165,13 +165,13 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
                .assertThat()
                .statusCode(HttpStatus.SC_CREATED)
                .body("bucket_name", is(bucket.getName()))
-               .body("name", is("WF_1_Rev_1"));
+               .body("name", is("WF_1_Rev_1.xml"));
     }
 
     @Test
     public void testCreateWorkflowRevisionShouldReturnUnprocessableEntityIfInvalidSyntax() {
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "WF_1_Rev_1")
+               .pathParam("name", "WF_1_Rev_1.xml")
                .queryParam("commitMessage", "first commit")
                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow-invalid-syntax.xml"))
                .when()
@@ -185,7 +185,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
     @Test
     public void testCreateWorkflowRevisionShouldReturnCreatedIfNoProjectNameInXmlPayload() {
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "WF_1_Rev_1")
+               .pathParam("name", "WF_1_Rev_1.xml")
                .queryParam("commitMessage", "first commit")
                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow-no-project-name.xml"))
                .when()
@@ -198,7 +198,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
     @Test
     public void testCreateWorkflowRevisionShouldReturnUnsupportedMediaTypeWithoutBody() {
         given().pathParam("bucketName", bucket.getName())
-               .pathParam("name", "WF_1_Rev_1")
+               .pathParam("name", "WF_1_Rev_1.xml")
                .when()
                .post(CATALOG_OBJECT_REVISIONS_RESOURCE)
                .then()
@@ -209,7 +209,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
     @Test
     public void testCreateWorkflowRevisionShouldReturnNotFoundIfNonExistingBucketName() {
         given().pathParam("bucketName", "non-existing-bucket")
-               .pathParam("name", "WF_1_Rev_1")
+               .pathParam("name", "WF_1_Rev_1.xml")
                .queryParam("commitMessage", "first commit")
                .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
                .when()
@@ -223,7 +223,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
     @Test
     public void testGetWorkflowRevisionShouldReturnSavedWorkflowRevision() throws UnsupportedEncodingException {
         ValidatableResponse validatableResponse = given().pathParam("bucketName", bucket.getName())
-                                                         .pathParam("name", "WF_1_Rev_1")
+                                                         .pathParam("name", "WF_1_Rev_1.xml")
                                                          .pathParam("commitTimeRaw",
                                                                     secondCatalogObjectRevisionCommitTime.atZone(ZoneId.systemDefault())
                                                                                                          .toInstant()
@@ -292,7 +292,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
     @Test
     public void testGetWorkflowRevisionPayloadShouldReturnSavedRawObject() throws IOException {
         Response response = given().pathParam("bucketName", bucket.getName())
-                                   .pathParam("name", "WF_1_Rev_1")
+                                   .pathParam("name", "WF_1_Rev_1.xml")
                                    .pathParam("commitTimeRaw",
                                               secondCatalogObjectRevisionCommitTime.atZone(ZoneId.systemDefault())
                                                                                    .toInstant()
@@ -410,7 +410,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
             }
 
             given().pathParam("bucketName", bucket.getName())
-                   .pathParam("name", "WF_1_Rev_1")
+                   .pathParam("name", "WF_1_Rev_1.xml")
                    .queryParam("commitMessage", "commit message")
                    .multiPart(IntegrationTestUtil.getWorkflowFile("workflow-updated.xml"))
                    .when()
@@ -420,7 +420,7 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
         });
 
         Response response = given().pathParam("bucketName", bucket.getName())
-                                   .pathParam("name", "WF_1_Rev_1")
+                                   .pathParam("name", "WF_1_Rev_1.xml")
                                    .when()
                                    .get(CATALOG_OBJECT_REVISIONS_RESOURCE);
 

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/BucketServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/BucketServiceIntegrationTest.java
@@ -95,6 +95,7 @@ public class BucketServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
+                                                 null,
                                                  null);
 
         BucketMetadata emptyBucket = bucketService.createBucket("bucketempty", "emptyBucketTest");
@@ -131,6 +132,7 @@ public class BucketServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
+                                                 null,
                                                  null);
 
         List<BucketMetadata> bucketMetadatas = bucketService.listBuckets("owner", Optional.empty(), Optional.empty());
@@ -153,6 +155,7 @@ public class BucketServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
+                                                 null,
                                                  null);
 
         //create bucket with kind object workflow/standard inside
@@ -163,6 +166,7 @@ public class BucketServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
+                                                 null,
                                                  null);
 
         //create bucket with kind object workflow/pca inside
@@ -173,6 +177,7 @@ public class BucketServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
+                                                 null,
                                                  null);
 
         //create bucket with kind object not-workflow inside
@@ -183,6 +188,7 @@ public class BucketServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
+                                                 null,
                                                  null);
 
         // test filtering by owner

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
@@ -130,6 +130,23 @@ public class CatalogObjectServiceIntegrationTest {
     }
 
     @Test
+    public void testGetAllKinds() {
+        List<String> listKinds = catalogObjectService.getKinds();
+        assertThat(listKinds).hasSize(2);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "object-name-4",
+                                                 "workflow/new",
+                                                 "commit message",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray);
+        listKinds = catalogObjectService.getKinds();
+        assertThat(listKinds).hasSize(3);
+        assertThat(listKinds).contains("workflow/new");
+    }
+
+    @Test
     public void testUpdateObjectMetadata() {
         CatalogObjectMetadata catalogObjectMetadata = catalogObjectService.updateObjectMetadata(bucket.getName(),
                                                                                                 "object-name-1",

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
@@ -93,7 +93,8 @@ public class CatalogObjectServiceIntegrationTest {
                                                                                        "commit message",
                                                                                        "application/xml",
                                                                                        keyValues,
-                                                                                       workflowAsByteArray);
+                                                                                       workflowAsByteArray,
+                                                                                       null);
         firstCommitTime = catalogObject.getCommitDateTime().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
 
         Thread.sleep(1); // to be sure that a new revision time will be different from previous revision time
@@ -110,7 +111,8 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 workflowAsByteArray);
+                                                 workflowAsByteArray,
+                                                 null);
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "object-name-3",
@@ -118,7 +120,8 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 workflowAsByteArray);
+                                                 workflowAsByteArray,
+                                                 null);
     }
 
     @After
@@ -143,7 +146,8 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 workflowAsByteArray);
+                                                 workflowAsByteArray,
+                                                 null);
         listKinds = catalogObjectService.getKinds();
         assertThat(listKinds).hasSize(3);
         assertThat(listKinds).contains("workflow/new");
@@ -177,7 +181,8 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 workflowAsByteArray);
+                                                 workflowAsByteArray,
+                                                 null);
     }
 
     @Test
@@ -192,7 +197,8 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 workflowAsByteArray);
+                                                 workflowAsByteArray,
+                                                 null);
 
         catalogObjects = catalogObjectService.listCatalogObjectsByKind(Arrays.asList(bucket.getName()),
                                                                        "workflow-general");

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/GraphqlServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/GraphqlServiceIntegrationTest.java
@@ -106,7 +106,8 @@ public class GraphqlServiceIntegrationTest {
                                                                                        "commit message",
                                                                                        "application/xml",
                                                                                        keyValues,
-                                                                                       workflowAsByteArray);
+                                                                                       workflowAsByteArray,
+                                                                                       null);
         firstCommitTime = catalogObject.getCommitDateTime().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
 
         Thread.sleep(1); // to be sure that a new revision time will be different from previous revision time
@@ -123,7 +124,8 @@ public class GraphqlServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 workflowAsByteArray);
+                                                 workflowAsByteArray,
+                                                 null);
 
         keyValues = Collections.singletonList(new Metadata("key", "value2", "type"));
 
@@ -133,7 +135,8 @@ public class GraphqlServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 workflowAsByteArray);
+                                                 workflowAsByteArray,
+                                                 null);
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog4",
@@ -141,7 +144,8 @@ public class GraphqlServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 workflowAsByteArray);
+                                                 workflowAsByteArray,
+                                                 null);
 
     }
 
@@ -441,7 +445,8 @@ public class GraphqlServiceIntegrationTest {
                                                  "commit message",
                                                  "application/xml",
                                                  keyValues,
-                                                 IntegrationTestUtil.getWorkflowAsByteArray("workflow.xml"));
+                                                 IntegrationTestUtil.getWorkflowAsByteArray("workflow.xml"),
+                                                 null);
 
         String query = "{\n" +
                        "  allCatalogObjects(where:{OR:[{AND:[{nameArg:{eq:\"catalog1\"}}, {kindArg:{eq:\"object\"}}, {metadataArg:{key:\"key2\", value:{like:\"%%\"}}}]}, {AND:[{kindArg:{eq:\"workflow\"}}, {metadataArg:{key:\"key\",value:{eq:\"value2\"}}}]}]}) {\n" +

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectMetadata.java
@@ -63,6 +63,9 @@ public class CatalogObjectMetadata extends ResourceSupport {
     @JsonProperty
     protected final String name;
 
+    @JsonProperty
+    protected final String extension;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty("commit_time")
     protected final LocalDateTime commitDateTime;
@@ -85,7 +88,8 @@ public class CatalogObjectMetadata extends ResourceSupport {
              catalogObject.getContentType(),
              catalogObject.getRevisions().first().getCommitTime(),
              catalogObject.getRevisions().first().getCommitMessage(),
-             KeyValueEntityToDtoTransformer.to(catalogObject.getRevisions().first().getKeyValueMetadataList()));
+             KeyValueEntityToDtoTransformer.to(catalogObject.getRevisions().first().getKeyValueMetadataList()),
+             catalogObject.getExtension());
     }
 
     public CatalogObjectMetadata(CatalogObjectRevisionEntity catalogObject) {
@@ -95,11 +99,12 @@ public class CatalogObjectMetadata extends ResourceSupport {
              catalogObject.getCatalogObject().getContentType(),
              catalogObject.getCommitTime(),
              catalogObject.getCommitMessage(),
-             KeyValueEntityToDtoTransformer.to(catalogObject.getKeyValueMetadataList()));
+             KeyValueEntityToDtoTransformer.to(catalogObject.getKeyValueMetadataList()),
+             catalogObject.getCatalogObject().getExtension());
     }
 
     public CatalogObjectMetadata(String bucketName, String name, String kind, String contentType, long commitTime,
-            String commitMessage, List<Metadata> metadataList) {
+            String commitMessage, List<Metadata> metadataList, String extension) {
         this.bucketName = bucketName;
         this.name = name;
         this.kind = kind;
@@ -113,6 +118,7 @@ public class CatalogObjectMetadata extends ResourceSupport {
             this.metadataList = metadataList;
         }
         this.projectName = getProjectNameIfExistsOrEmptyString();
+        this.extension = extension;
 
     }
 

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogRawObject.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogRawObject.java
@@ -53,8 +53,8 @@ public class CatalogRawObject extends CatalogObjectMetadata {
     }
 
     public CatalogRawObject(String bucketName, String name, String kind, String contentType, long createdAt,
-            String commitMessage, List<Metadata> metadataList, byte[] rawObject) {
-        super(bucketName, name, kind, contentType, createdAt, commitMessage, metadataList);
+            String commitMessage, List<Metadata> metadataList, byte[] rawObject, String extension) {
+        super(bucketName, name, kind, contentType, createdAt, commitMessage, metadataList, extension);
         this.rawObject = rawObject;
     }
 

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRepository.java
@@ -25,10 +25,13 @@
  */
 package org.ow2.proactive.catalog.repository;
 
+import java.util.List;
+
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectEntity;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 
 
@@ -41,4 +44,7 @@ public interface CatalogObjectRepository
 
     @EntityGraph("catalogObject.withRevisions")
     CatalogObjectEntity readCatalogObjectRevisionsById(CatalogObjectEntity.CatalogObjectEntityKey key);
+
+    @Query(value = "SELECT DISTINCT cos.kind FROM CatalogObjectEntity cos")
+    List<String> findAllKinds();
 }

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectEntity.java
@@ -118,6 +118,9 @@ public class CatalogObjectEntity implements Serializable {
     @Column(name = "KIND", nullable = false)
     private String kind;
 
+    @Column(name = "EXTENSION")
+    private String extension;
+
     @OneToMany(mappedBy = "catalogObject", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST,
                                                                                CascadeType.REMOVE }, orphanRemoval = true)
     @OrderBy("commitTime DESC")

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -40,6 +40,7 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.io.FilenameUtils;
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadataList;
 import org.ow2.proactive.catalog.dto.CatalogRawObject;
@@ -119,7 +120,9 @@ public class CatalogObjectController {
                                                                                            kind,
                                                                                            commitMessage,
                                                                                            objectContentType,
-                                                                                           file.getBytes());
+                                                                                           file.getBytes(),
+                                                                                           FilenameUtils.getExtension(file.getOriginalFilename()));
+
             catalogObject.add(LinkUtil.createLink(bucketName, catalogObject.getName()));
 
             return new CatalogObjectMetadataList(catalogObject);

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -135,10 +135,11 @@ public class CatalogObjectController {
     }
 
     @ApiOperation(value = "Lists all kinds for all objects")
-    @RequestMapping(value = "/kinds", method = GET)
+    @RequestMapping(value = "/kinds", method = GET, produces = "application/json")
     @ResponseStatus(HttpStatus.OK)
-    public List<String> listKinds() {
-        return catalogObjectService.getKinds();
+    public ResponseEntity<List<String>> listKinds() {
+        List<String> allKinds = catalogObjectService.getKinds();
+        return ResponseEntity.ok(allKinds);
     }
 
     @ApiOperation(value = "Update a catalog object metadata, like kind and content type")

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -147,7 +147,7 @@ public class CatalogObjectController {
                             @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied"),
                             @ApiResponse(code = 400, message = "Wrong specified parameters: at least one should be present") })
-    @RequestMapping(value = REQUEST_API_QUERY + "/{name}", method = PUT)
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name:.+}", method = PUT)
     @ResponseStatus(HttpStatus.OK)
     public CatalogObjectMetadata updateObjectMetadata(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
@@ -166,7 +166,7 @@ public class CatalogObjectController {
                             @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied") })
     @ResponseStatus(HttpStatus.OK)
-    @RequestMapping(value = REQUEST_API_QUERY + "/{name}", method = GET)
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name:.+}", method = GET)
     public CatalogObjectMetadata get(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @PathVariable String bucketName, @PathVariable String name) throws MalformedURLException,
@@ -187,7 +187,7 @@ public class CatalogObjectController {
                             @ApiResponse(code = 403, message = "Permission denied"),
                             @ApiResponse(code = 404, message = "Bucket, catalog object or catalog object revision not found") })
 
-    @RequestMapping(value = REQUEST_API_QUERY + "/{name}/raw", method = GET, produces = MediaType.ALL_VALUE)
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name:.+}/raw", method = GET, produces = MediaType.ALL_VALUE)
     public ResponseEntity<String> getRaw(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @PathVariable String bucketName, @PathVariable String name)
@@ -273,7 +273,7 @@ public class CatalogObjectController {
     @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket or object not found"),
                             @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied") })
-    @RequestMapping(value = REQUEST_API_QUERY + "/{name}", method = DELETE)
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name:.+}", method = DELETE)
     public CatalogObjectMetadata delete(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @PathVariable String bucketName, @PathVariable String name)

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -75,8 +75,9 @@ import lombok.extern.log4j.Log4j2;
  */
 @RestController
 @Log4j2
-@RequestMapping(value = "/buckets/{bucketName}/resources")
 public class CatalogObjectController {
+
+    private static final String REQUEST_API_QUERY = "/buckets/{bucketName}/resources";
 
     @Autowired
     private CatalogObjectService catalogObjectService;
@@ -95,7 +96,7 @@ public class CatalogObjectController {
     @ApiOperation(value = "Creates a new catalog object")
     @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket not found"),
                             @ApiResponse(code = 422, message = "Invalid file content supplied") })
-    @RequestMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE }, method = POST)
+    @RequestMapping(value = REQUEST_API_QUERY, consumes = { MediaType.MULTIPART_FORM_DATA_VALUE }, method = POST)
     @ResponseStatus(HttpStatus.CREATED)
     public CatalogObjectMetadataList create(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
@@ -133,12 +134,19 @@ public class CatalogObjectController {
         }
     }
 
+    @ApiOperation(value = "Lists all kinds for all objects")
+    @RequestMapping(value = "/kinds", method = GET)
+    @ResponseStatus(HttpStatus.OK)
+    public List<String> listKinds() {
+        return catalogObjectService.getKinds();
+    }
+
     @ApiOperation(value = "Update a catalog object metadata, like kind and content type")
     @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket, object or revision not found"),
                             @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied"),
                             @ApiResponse(code = 400, message = "Wrong specified parameters: at least one should be present") })
-    @RequestMapping(value = "/{name}", method = PUT)
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name}", method = PUT)
     @ResponseStatus(HttpStatus.OK)
     public CatalogObjectMetadata updateObjectMetadata(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
@@ -157,7 +165,7 @@ public class CatalogObjectController {
                             @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied") })
     @ResponseStatus(HttpStatus.OK)
-    @RequestMapping(value = "/{name}", method = GET)
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name}", method = GET)
     public CatalogObjectMetadata get(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @PathVariable String bucketName, @PathVariable String name) throws MalformedURLException,
@@ -178,7 +186,7 @@ public class CatalogObjectController {
                             @ApiResponse(code = 403, message = "Permission denied"),
                             @ApiResponse(code = 404, message = "Bucket, catalog object or catalog object revision not found") })
 
-    @RequestMapping(value = "/{name}/raw", method = GET, produces = MediaType.ALL_VALUE)
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name}/raw", method = GET, produces = MediaType.ALL_VALUE)
     public ResponseEntity<String> getRaw(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @PathVariable String bucketName, @PathVariable String name)
@@ -197,7 +205,7 @@ public class CatalogObjectController {
                             @ApiResponse(code = 206, message = "Missing object"),
                             @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied") })
-    @RequestMapping(method = GET)
+    @RequestMapping(value = REQUEST_API_QUERY, method = GET)
     public ResponseEntity<List<CatalogObjectMetadata>> list(
             @ApiParam(value = "sessionID") @RequestHeader(value = "sessionID", required = false) String sessionId,
             @PathVariable String bucketName,
@@ -264,7 +272,7 @@ public class CatalogObjectController {
     @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket or object not found"),
                             @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied") })
-    @RequestMapping(value = "/{name}", method = DELETE)
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name}", method = DELETE)
     public CatalogObjectMetadata delete(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @PathVariable String bucketName, @PathVariable String name)

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
@@ -66,7 +66,7 @@ import lombok.extern.log4j.Log4j2;
  * @author ActiveEon Team
  */
 @RestController
-@RequestMapping("/buckets/{bucketName}/resources/{name}/revisions")
+@RequestMapping("/buckets/{bucketName}/resources/{name:.+}/revisions")
 @Log4j2
 public class CatalogObjectRevisionController {
 

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -136,18 +136,21 @@ public class CatalogObjectService {
 
         return filesContainedInArchive.stream().map(file -> {
             CatalogObjectEntity catalogObject = catalogObjectRepository.findOne(new CatalogObjectEntity.CatalogObjectEntityKey(bucketEntity.getId(),
-                                                                                                                               file.getName()));
+                                                                                                                               file.getFileNameWithExtension()));
             if (catalogObject == null) {
                 String contentTypeOfFile = getFileMimeType(file);
                 return this.createCatalogObject(bucketName,
-                                                file.getName(),
+                                                file.getFileNameWithExtension(),
                                                 kind,
                                                 commitMessage,
                                                 contentTypeOfFile,
                                                 Collections.emptyList(),
                                                 file.getContent());
             } else {
-                return this.createCatalogObjectRevision(bucketName, file.getName(), commitMessage, file.getContent());
+                return this.createCatalogObjectRevision(bucketName,
+                                                        file.getFileNameWithExtension(),
+                                                        commitMessage,
+                                                        file.getContent());
             }
         }).collect(Collectors.toList());
     }

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -401,6 +401,10 @@ public class CatalogObjectService {
         return new CatalogObjectMetadata(restoredRevision);
     }
 
+    public List<String> getKinds() {
+        return catalogObjectRepository.findAllKinds();
+    }
+
     @VisibleForTesting
     protected CatalogObjectRevisionEntity getCatalogObjectRevisionEntityByCommitTime(String bucketName, String name,
             long commitTime) {

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AutoDetectParser;
@@ -114,14 +115,15 @@ public class CatalogObjectService {
     private AutoDetectParser mediaTypeFileParser = new AutoDetectParser();
 
     public CatalogObjectMetadata createCatalogObject(String bucketName, String name, String kind, String commitMessage,
-            String contentType, byte[] rawObject) {
+            String contentType, byte[] rawObject, String extension) {
         return this.createCatalogObject(bucketName,
                                         name,
                                         kind,
                                         commitMessage,
                                         contentType,
                                         Collections.emptyList(),
-                                        rawObject);
+                                        rawObject,
+                                        extension);
     }
 
     public List<CatalogObjectMetadata> createCatalogObjects(String bucketName, String kind, String commitMessage,
@@ -135,24 +137,55 @@ public class CatalogObjectService {
         BucketEntity bucketEntity = findBucketByNameAndCheck(bucketName);
 
         return filesContainedInArchive.stream().map(file -> {
+            String objectName = file.getName();
             CatalogObjectEntity catalogObject = catalogObjectRepository.findOne(new CatalogObjectEntity.CatalogObjectEntityKey(bucketEntity.getId(),
-                                                                                                                               file.getFileNameWithExtension()));
+                                                                                                                               objectName));
             if (catalogObject == null) {
                 String contentTypeOfFile = getFileMimeType(file);
                 return this.createCatalogObject(bucketName,
-                                                file.getFileNameWithExtension(),
+                                                objectName,
                                                 kind,
                                                 commitMessage,
                                                 contentTypeOfFile,
                                                 Collections.emptyList(),
-                                                file.getContent());
+                                                file.getContent(),
+                                                FilenameUtils.getExtension(file.getFileNameWithExtension()));
             } else {
-                return this.createCatalogObjectRevision(bucketName,
-                                                        file.getFileNameWithExtension(),
-                                                        commitMessage,
-                                                        file.getContent());
+                return this.createCatalogObjectRevision(bucketName, objectName, commitMessage, file.getContent());
             }
         }).collect(Collectors.toList());
+    }
+
+    public CatalogObjectMetadata createCatalogObject(String bucketName, String name, String kind, String commitMessage,
+            String contentType, List<Metadata> metadataList, byte[] rawObject, String extension) {
+        if (!kindNameValidator.isValid(kind)) {
+            throw new KindNameIsNotValidException(kind);
+        }
+
+        BucketEntity bucketEntity = findBucketByNameAndCheck(bucketName);
+
+        CatalogObjectRevisionEntity catalogObjectEntityCheck = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(Collections.singletonList(bucketName),
+                                                                                                                                      name);
+        if (catalogObjectEntityCheck != null) {
+            throw new CatalogObjectAlreadyExistingException(bucketName, name);
+        }
+
+        CatalogObjectEntity catalogObjectEntity = CatalogObjectEntity.builder()
+                                                                     .bucket(bucketEntity)
+                                                                     .contentType(contentType)
+                                                                     .kind(kind)
+                                                                     .extension(extension)
+                                                                     .id(new CatalogObjectEntity.CatalogObjectEntityKey(bucketEntity.getId(),
+                                                                                                                        name))
+                                                                     .build();
+        bucketEntity.getCatalogObjects().add(catalogObjectEntity);
+
+        CatalogObjectRevisionEntity result = buildCatalogObjectRevisionEntity(commitMessage,
+                                                                              metadataList,
+                                                                              rawObject,
+                                                                              catalogObjectEntity);
+
+        return new CatalogObjectMetadata(result);
     }
 
     private String getFileMimeType(FileNameAndContent file) {
@@ -185,37 +218,6 @@ public class CatalogObjectService {
         contentType.ifPresent(catalogObjectEntity::setContentType);
         catalogObjectRepository.save(catalogObjectEntity);
         return new CatalogObjectMetadata(catalogObjectEntity);
-    }
-
-    public CatalogObjectMetadata createCatalogObject(String bucketName, String name, String kind, String commitMessage,
-            String contentType, List<Metadata> metadataList, byte[] rawObject) {
-        if (!kindNameValidator.isValid(kind)) {
-            throw new KindNameIsNotValidException(kind);
-        }
-
-        BucketEntity bucketEntity = findBucketByNameAndCheck(bucketName);
-
-        CatalogObjectRevisionEntity catalogObjectEntityCheck = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(Collections.singletonList(bucketName),
-                                                                                                                                      name);
-        if (catalogObjectEntityCheck != null) {
-            throw new CatalogObjectAlreadyExistingException(bucketName, name);
-        }
-
-        CatalogObjectEntity catalogObjectEntity = CatalogObjectEntity.builder()
-                                                                     .bucket(bucketEntity)
-                                                                     .contentType(contentType)
-                                                                     .kind(kind)
-                                                                     .id(new CatalogObjectEntity.CatalogObjectEntityKey(bucketEntity.getId(),
-                                                                                                                        name))
-                                                                     .build();
-        bucketEntity.getCatalogObjects().add(catalogObjectEntity);
-
-        CatalogObjectRevisionEntity result = buildCatalogObjectRevisionEntity(commitMessage,
-                                                                              metadataList,
-                                                                              rawObject,
-                                                                              catalogObjectEntity);
-
-        return new CatalogObjectMetadata(result);
     }
 
     private BucketEntity findBucketByNameAndCheck(String bucketName) {

--- a/src/main/java/org/ow2/proactive/catalog/util/ArchiveManagerHelper.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/ArchiveManagerHelper.java
@@ -127,8 +127,14 @@ public class ArchiveManagerHelper {
                     zipContent.setPartial(true);
                 }
                 return catalogObjectRevision != null;
-            }).map(catalogObjectRevision -> new ByteSource(catalogObjectRevision.getCatalogObject().getId().getName(),
-                                                           catalogObjectRevision.getRawObject()));
+            }).map(catalogObjectRevision -> {
+                String fileExtension = catalogObjectRevision.getCatalogObject().getExtension();
+                String fileNameWithExtension = catalogObjectRevision.getCatalogObject().getId().getName();
+                if (fileExtension != null) {
+                    fileNameWithExtension += "." + fileExtension;
+                }
+                return new ByteSource(fileNameWithExtension, catalogObjectRevision.getRawObject());
+            });
             ZipEntrySource[] sources = streamSources.toArray(size -> new ZipEntrySource[size]);
             ZipUtil.pack(sources, byteArrayOutputStream);
 

--- a/src/main/java/org/ow2/proactive/catalog/util/ArchiveManagerHelper.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/ArchiveManagerHelper.java
@@ -35,7 +35,9 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.io.FilenameUtils;
+import org.ow2.proactive.catalog.repository.entity.CatalogObjectEntity;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zeroturnaround.zip.ByteSource;
 import org.zeroturnaround.zip.ZipEntrySource;
@@ -44,6 +46,9 @@ import org.zeroturnaround.zip.ZipUtil;
 
 @Component
 public class ArchiveManagerHelper {
+
+    @Autowired
+    private RawObjectResponseCreator rawObjectResponseCreator;
 
     public static class ZipArchiveContent {
 
@@ -128,11 +133,11 @@ public class ArchiveManagerHelper {
                 }
                 return catalogObjectRevision != null;
             }).map(catalogObjectRevision -> {
-                String fileExtension = catalogObjectRevision.getCatalogObject().getExtension();
-                String fileNameWithExtension = catalogObjectRevision.getCatalogObject().getId().getName();
-                if (fileExtension != null) {
-                    fileNameWithExtension += "." + fileExtension;
-                }
+                CatalogObjectEntity catalogObjectEntity = catalogObjectRevision.getCatalogObject();
+                String fileNameWithExtension = rawObjectResponseCreator.getNameWithFileExtension(catalogObjectEntity.getId()
+                                                                                                                    .getName(),
+                                                                                                 catalogObjectEntity.getExtension(),
+                                                                                                 catalogObjectEntity.getKind());
                 return new ByteSource(fileNameWithExtension, catalogObjectRevision.getRawObject());
             });
             ZipEntrySource[] sources = streamSources.toArray(size -> new ZipEntrySource[size]);

--- a/src/main/java/org/ow2/proactive/catalog/util/RawObjectResponseCreator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/RawObjectResponseCreator.java
@@ -57,11 +57,17 @@ public class RawObjectResponseCreator {
 
         try {
             String contentDispositionFileName = name;
+            String fileExtension = rawObject.getExtension();
 
+            if (fileExtension != null) {
+                contentDispositionFileName += "." + fileExtension;
+            }
             //add the .xml extension to contentDispositionFileName for workflow if the extension was not yet in name
-            if (rawObject.getKind() != null && rawObject.getContentType() != null &&
-                rawObject.getKind().toLowerCase().startsWith(SupportedParserKinds.WORKFLOW.toString().toLowerCase()) &&
-                !name.endsWith(WORKFLOW_EXTENSION)) {
+            else if (rawObject.getKind() != null && rawObject.getContentType() != null &&
+                     rawObject.getKind()
+                              .toLowerCase()
+                              .startsWith(SupportedParserKinds.WORKFLOW.toString().toLowerCase()) &&
+                     !name.endsWith(WORKFLOW_EXTENSION)) {
                 contentDispositionFileName += WORKFLOW_EXTENSION;
             }
             responseBodyBuilder.header(HttpHeaders.CONTENT_DISPOSITION,

--- a/src/main/java/org/ow2/proactive/catalog/util/RawObjectResponseCreator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/RawObjectResponseCreator.java
@@ -50,26 +50,15 @@ public class RawObjectResponseCreator {
 
     public ResponseEntity createRawObjectResponse(CatalogRawObject rawObject) {
         String name = rawObject.getName();
-
         byte[] bytes = rawObject.getRawObject();
 
         ResponseEntity.BodyBuilder responseBodyBuilder = ResponseEntity.ok().contentLength(bytes.length);
 
         try {
-            String contentDispositionFileName = name;
-            String fileExtension = rawObject.getExtension();
+            String contentDispositionFileName = getNameWithFileExtension(rawObject.getName(),
+                                                                         rawObject.getExtension(),
+                                                                         rawObject.getKind());
 
-            if (fileExtension != null) {
-                contentDispositionFileName += "." + fileExtension;
-            }
-            //add the .xml extension to contentDispositionFileName for workflow if the extension was not yet in name
-            else if (rawObject.getKind() != null && rawObject.getContentType() != null &&
-                     rawObject.getKind()
-                              .toLowerCase()
-                              .startsWith(SupportedParserKinds.WORKFLOW.toString().toLowerCase()) &&
-                     !name.endsWith(WORKFLOW_EXTENSION)) {
-                contentDispositionFileName += WORKFLOW_EXTENSION;
-            }
             responseBodyBuilder.header(HttpHeaders.CONTENT_DISPOSITION,
                                        "attachment; filename=\"" + contentDispositionFileName + "\"");
         } catch (Exception e) {
@@ -85,5 +74,27 @@ public class RawObjectResponseCreator {
         }
 
         return responseBodyBuilder.body(new InputStreamResource(new ByteArrayInputStream(bytes)));
+    }
+
+    /**
+     *
+     * @param name
+     * @param fileExtension
+     * @param kind
+     * @return object's name with added extension
+     * if extension doesn't exist for workflow it will be added .xml
+     */
+    public String getNameWithFileExtension(String name, String fileExtension, String kind) {
+
+        if (fileExtension != null && !fileExtension.isEmpty()) {
+            name += "." + fileExtension;
+        }
+        //add the .xml extension to contentDispositionFileName for workflow if the extension was not yet in name
+        else if (kind != null &&
+                 kind.toLowerCase().startsWith(SupportedParserKinds.WORKFLOW.toString().toLowerCase()) &&
+                 !name.endsWith(WORKFLOW_EXTENSION)) {
+            name += WORKFLOW_EXTENSION;
+        }
+        return name;
     }
 }

--- a/src/test/java/org/ow2/proactive/catalog/dto/CatalogObjectMetadataTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/dto/CatalogObjectMetadataTest.java
@@ -72,7 +72,8 @@ public class CatalogObjectMetadataTest {
                                                                                 "contentType",
                                                                                 123546587L,
                                                                                 "commitMessage",
-                                                                                metadataList);
+                                                                                metadataList,
+                                                                                "xml");
         return catalogObjectMetadata;
     }
 

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
@@ -151,7 +151,8 @@ public class CatalogObjectControllerTest {
                                                           1400343L,
                                                           "commit message",
                                                           Collections.emptyList(),
-                                                          new byte[0]);
+                                                          new byte[0],
+                                                          "xml");
         ResponseEntity responseEntity = ResponseEntity.ok().body(1);
         when(catalogObjectService.getCatalogRawObject(anyString(), anyString())).thenReturn(rawObject);
         when(rawObjectResponseCreator.createRawObjectResponse(rawObject)).thenReturn(responseEntity);
@@ -170,7 +171,8 @@ public class CatalogObjectControllerTest {
                                                                "application/xml",
                                                                1400343L,
                                                                "commit message",
-                                                               Collections.emptyList());
+                                                               Collections.emptyList(),
+                                                               "xml");
         when(catalogObjectService.delete(anyString(), anyString())).thenReturn(mock);
         CatalogObjectMetadata result = catalogObjectController.delete("", "bucket-name", "name");
         assertThat(mock).isEqualTo(result);

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerTest.java
@@ -79,7 +79,8 @@ public class CatalogObjectRevisionControllerTest {
                                                           1400343L,
                                                           "commit message",
                                                           Collections.emptyList(),
-                                                          new byte[0]);
+                                                          new byte[0],
+                                                          "xml");
         ResponseEntity responseEntity = ResponseEntity.ok().body(1);
         when(catalogObjectService.getCatalogObjectRevisionRaw(anyString(),
                                                               anyString(),

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectReportServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectReportServiceTest.java
@@ -201,7 +201,8 @@ public class CatalogObjectReportServiceTest {
                                                                                 "contentType",
                                                                                 System.currentTimeMillis(),
                                                                                 "commitMessage",
-                                                                                metadataList);
+                                                                                metadataList,
+                                                                                "xml");
         return catalogObjectMetadata;
     }
 }

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
@@ -105,7 +105,7 @@ public class CatalogObjectServiceTest {
     public void testCreateCatalogObjectWithInvalidBucket() {
         when(kindNameValidator.isValid(anyString())).thenReturn(true);
         when(bucketRepository.findOneByBucketName(anyString())).thenReturn(null);
-        catalogObjectService.createCatalogObject("bucket", NAME, OBJECT, COMMIT_MESSAGE, APPLICATION_XML, null);
+        catalogObjectService.createCatalogObject("bucket", NAME, OBJECT, COMMIT_MESSAGE, APPLICATION_XML, null, null);
     }
 
     /**
@@ -149,6 +149,7 @@ public class CatalogObjectServiceTest {
                                                                                        COMMIT_MESSAGE,
                                                                                        APPLICATION_XML,
                                                                                        keyValues,
+                                                                                       null,
                                                                                        null);
         assertThat(catalogObject).isNotNull();
         assertThat(catalogObject.getCommitMessage()).isEqualTo(COMMIT_MESSAGE);

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
@@ -131,12 +131,6 @@ public class CatalogObjectServiceTest {
     }
 
     @Test
-    public void testGetKinds() {
-        catalogObjectRepository.findAllKinds();
-        verify(catalogObjectRepository, times(1)).findAllKinds();
-    }
-
-    @Test
     public void testCreateCatalogObject() {
         BucketEntity bucketEntity = new BucketEntity("bucket", "toto");
         when(kindNameValidator.isValid(anyString())).thenReturn(true);

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
@@ -99,6 +99,12 @@ public class CatalogObjectServiceTest {
     }
 
     @Test
+    public void testGetKinds() {
+        catalogObjectRepository.findAllKinds();
+        verify(catalogObjectRepository, times(1)).findAllKinds();
+    }
+
+    @Test
     public void testCreateCatalogObject() {
         BucketEntity bucketEntity = new BucketEntity("bucket", "toto");
         when(bucketRepository.findOneByBucketName(anyString())).thenReturn(bucketEntity);

--- a/src/test/java/org/ow2/proactive/catalog/util/ArchiveManagerHelperTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/ArchiveManagerHelperTest.java
@@ -81,10 +81,11 @@ public class ArchiveManagerHelperTest {
         ZIP_FILE_DIFF_TYPES = ArchiveManagerHelperTest.class.getResource("/archives/archiveDiffTypes.zip").toURI();
     }
 
-    private CatalogObjectRevisionEntity getCatalogObjectRevisionEntity(String name, byte[] fileContent)
-            throws IOException {
+    private CatalogObjectRevisionEntity getCatalogObjectRevisionEntity(String name, byte[] fileContent,
+            String extension) throws IOException {
         CatalogObjectEntity object = new CatalogObjectEntity();
         object.setId(new CatalogObjectEntityKey(1L, name));
+        object.setExtension(extension);
 
         CatalogObjectRevisionEntity revision = new CatalogObjectRevisionEntity();
         revision.setCatalogObject(object);
@@ -101,8 +102,8 @@ public class ArchiveManagerHelperTest {
         byte[] workflowByteArray0 = convertFromURIToByteArray(XML_FILE_0);
         byte[] jsonByteArray1 = convertFromURIToByteArray(XML_FILE_1);
         List<CatalogObjectRevisionEntity> expectedFiles = new ArrayList<>();
-        expectedFiles.add(getCatalogObjectRevisionEntity("workflow_0", workflowByteArray0));
-        expectedFiles.add(getCatalogObjectRevisionEntity("array", jsonByteArray1));
+        expectedFiles.add(getCatalogObjectRevisionEntity("workflow_0", workflowByteArray0, "xml"));
+        expectedFiles.add(getCatalogObjectRevisionEntity("array", jsonByteArray1, "json"));
         //Compress
         ZipArchiveContent archive = archiveManager.compressZIP(expectedFiles);
         //Then extract
@@ -111,6 +112,8 @@ public class ArchiveManagerHelperTest {
 
         compare(workflowByteArray0, actualFiles.get(0).getContent());
         compare(jsonByteArray1, actualFiles.get(1).getContent());
+        assertEquals("workflow_0.xml", actualFiles.get(0).getFileNameWithExtension());
+        assertEquals("array.json", actualFiles.get(1).getFileNameWithExtension());
     }
 
     @Test
@@ -121,8 +124,8 @@ public class ArchiveManagerHelperTest {
         byte[] workflowByteArray0 = convertFromURIToByteArray(XML_FILE_0);
         byte[] workflowByteArray1 = convertFromURIToByteArray(XML_FILE_1);
         List<CatalogObjectRevisionEntity> expectedFiles = new ArrayList<>();
-        expectedFiles.add(getCatalogObjectRevisionEntity("workflow_0", workflowByteArray0));
-        expectedFiles.add(getCatalogObjectRevisionEntity("workflow_1", workflowByteArray1));
+        expectedFiles.add(getCatalogObjectRevisionEntity("workflow_0", workflowByteArray0, "xml"));
+        expectedFiles.add(getCatalogObjectRevisionEntity("workflow_1", workflowByteArray1, "xml"));
         //Compress
         ZipArchiveContent archive = archiveManager.compressZIP(expectedFiles);
         //Then extract

--- a/src/test/java/org/ow2/proactive/catalog/util/ArchiveManagerHelperTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/ArchiveManagerHelperTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -44,6 +45,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectEntity;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectEntity.CatalogObjectEntityKey;
@@ -63,6 +65,9 @@ public class ArchiveManagerHelperTest {
     private static URI ZIP_FILE;
 
     private static URI ZIP_FILE_DIFF_TYPES;
+
+    @Mock
+    private RawObjectResponseCreator rawObjectResponseCreator;
 
     @InjectMocks
     private ArchiveManagerHelper archiveManager;
@@ -101,6 +106,8 @@ public class ArchiveManagerHelperTest {
 
         byte[] workflowByteArray0 = convertFromURIToByteArray(XML_FILE_0);
         byte[] jsonByteArray1 = convertFromURIToByteArray(XML_FILE_1);
+        when(rawObjectResponseCreator.getNameWithFileExtension("workflow_0", "xml", null)).thenReturn("workflow_0.xml");
+        when(rawObjectResponseCreator.getNameWithFileExtension("array", "json", null)).thenReturn("array.json");
         List<CatalogObjectRevisionEntity> expectedFiles = new ArrayList<>();
         expectedFiles.add(getCatalogObjectRevisionEntity("workflow_0", workflowByteArray0, "xml"));
         expectedFiles.add(getCatalogObjectRevisionEntity("array", jsonByteArray1, "json"));
@@ -126,6 +133,8 @@ public class ArchiveManagerHelperTest {
         List<CatalogObjectRevisionEntity> expectedFiles = new ArrayList<>();
         expectedFiles.add(getCatalogObjectRevisionEntity("workflow_0", workflowByteArray0, "xml"));
         expectedFiles.add(getCatalogObjectRevisionEntity("workflow_1", workflowByteArray1, "xml"));
+        when(rawObjectResponseCreator.getNameWithFileExtension("workflow_0", "xml", null)).thenReturn("workflow_0.xml");
+        when(rawObjectResponseCreator.getNameWithFileExtension("workflow_1", "xml", null)).thenReturn("array.json");
         //Compress
         ZipArchiveContent archive = archiveManager.compressZIP(expectedFiles);
         //Then extract

--- a/src/test/java/org/ow2/proactive/catalog/util/ArchiveManagerHelperTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/ArchiveManagerHelperTest.java
@@ -134,7 +134,7 @@ public class ArchiveManagerHelperTest {
         expectedFiles.add(getCatalogObjectRevisionEntity("workflow_0", workflowByteArray0, "xml"));
         expectedFiles.add(getCatalogObjectRevisionEntity("workflow_1", workflowByteArray1, "xml"));
         when(rawObjectResponseCreator.getNameWithFileExtension("workflow_0", "xml", null)).thenReturn("workflow_0.xml");
-        when(rawObjectResponseCreator.getNameWithFileExtension("workflow_1", "xml", null)).thenReturn("array.json");
+        when(rawObjectResponseCreator.getNameWithFileExtension("workflow_1", "xml", null)).thenReturn("workflow_1.xml");
         //Compress
         ZipArchiveContent archive = archiveManager.compressZIP(expectedFiles);
         //Then extract
@@ -143,6 +143,8 @@ public class ArchiveManagerHelperTest {
 
         compare(workflowByteArray0, actualFiles.get(0).getContent());
         compare(workflowByteArray1, actualFiles.get(1).getContent());
+        assertEquals("workflow_0.xml", actualFiles.get(0).getFileNameWithExtension());
+        assertEquals("workflow_1.xml", actualFiles.get(1).getFileNameWithExtension());
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
@@ -71,6 +71,31 @@ public class RawObjectResponseCreatorTest {
     }
 
     @Test
+    public void testCreateRawObjectResponseWorkflowKindWithXMLExtension() {
+        String objectName = "object name";
+        String fileExtension = "xml";
+        String contentDispositionFileName = "attachment; filename=\"" + objectName + "." + fileExtension + "\"";
+        CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
+                                                          objectName,
+                                                          "workflow",
+                                                          "application/xml",
+                                                          1400343L,
+                                                          "commit message",
+                                                          Collections.emptyList(),
+                                                          new byte[0],
+                                                          fileExtension);
+        ResponseEntity responseEntity = rawObjectResponseCreator.createRawObjectResponse(rawObject);
+        assertThat(responseEntity).isNotNull();
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_XML);
+        assertThat(responseEntity.getHeaders().containsKey(HttpHeaders.CONTENT_DISPOSITION)).isTrue();
+        assertThat(responseEntity.getHeaders()
+                                 .getFirst(HttpHeaders.CONTENT_DISPOSITION)).isEqualTo(contentDispositionFileName);
+        assertThat(responseEntity.getHeaders()
+                                 .getFirst(HttpHeaders.CONTENT_LENGTH)).isEqualTo(String.valueOf(rawObject.getRawObject().length));
+    }
+
+    @Test
     public void testCreateRawObjectResponseWorkflowKindWithoutExtension() {
         String objectName = "object name";
         String contentDispositionFileName = "attachment; filename=\"" + objectName +
@@ -94,8 +119,31 @@ public class RawObjectResponseCreatorTest {
     }
 
     @Test
+    public void testCreateRawObjectResponseWorkflowKindWithEmptyExtension() {
+        String objectName = "object name";
+        String contentDispositionFileName = "attachment; filename=\"" + objectName +
+                                            RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
+        CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
+                                                          objectName,
+                                                          "workflow/specific-workflow-kind",
+                                                          "application/xml",
+                                                          1400343L,
+                                                          "commit message",
+                                                          Collections.emptyList(),
+                                                          new byte[0],
+                                                          "");
+        ResponseEntity responseEntity = rawObjectResponseCreator.createRawObjectResponse(rawObject);
+        assertThat(responseEntity).isNotNull();
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_XML);
+        assertThat(responseEntity.getHeaders().containsKey(HttpHeaders.CONTENT_DISPOSITION)).isTrue();
+        assertThat(responseEntity.getHeaders()
+                                 .getFirst(HttpHeaders.CONTENT_DISPOSITION)).isEqualTo(contentDispositionFileName);
+    }
+
+    @Test
     public void testCreateRawObjectResponseWorkflowKindWithExtensionInName() {
-        String objectName = "object name.json";
+        String objectName = "object name.xml";
         String contentDispositionFileName = "attachment; filename=\"" + objectName +
                                             RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",

--- a/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
@@ -56,7 +56,8 @@ public class RawObjectResponseCreatorTest {
                                                           1400343L,
                                                           "commit message",
                                                           Collections.emptyList(),
-                                                          new byte[0]);
+                                                          new byte[0],
+                                                          "xml");
         ResponseEntity responseEntity = rawObjectResponseCreator.createRawObjectResponse(rawObject);
         assertThat(responseEntity).isNotNull();
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -80,7 +81,8 @@ public class RawObjectResponseCreatorTest {
                                                           1400343L,
                                                           "commit message",
                                                           Collections.emptyList(),
-                                                          new byte[0]);
+                                                          new byte[0],
+                                                          "xml");
         ResponseEntity responseEntity = rawObjectResponseCreator.createRawObjectResponse(rawObject);
         assertThat(responseEntity).isNotNull();
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -101,7 +103,8 @@ public class RawObjectResponseCreatorTest {
                                                           1400343L,
                                                           "commit message",
                                                           Collections.emptyList(),
-                                                          new byte[0]);
+                                                          new byte[0],
+                                                          "xml");
         ResponseEntity responseEntity = rawObjectResponseCreator.createRawObjectResponse(rawObject);
         assertThat(responseEntity).isNotNull();
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -120,7 +123,8 @@ public class RawObjectResponseCreatorTest {
                                                           1400343L,
                                                           "commit message",
                                                           Collections.emptyList(),
-                                                          new byte[0]);
+                                                          new byte[0],
+                                                          "xml");
         ResponseEntity responseEntity = rawObjectResponseCreator.createRawObjectResponse(rawObject);
         assertThat(responseEntity).isNotNull();
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
@@ -48,7 +48,8 @@ public class RawObjectResponseCreatorTest {
     @Test
     public void testCreateRawObjectResponseGeneralKindRightContentType() {
         String objectName = "object name";
-        String contentDispositionFileName = "attachment; filename=\"" + objectName + "\"";
+        String fileExtension = "myextension";
+        String contentDispositionFileName = "attachment; filename=\"" + objectName + "." + fileExtension + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
                                                           "object",
@@ -57,7 +58,7 @@ public class RawObjectResponseCreatorTest {
                                                           "commit message",
                                                           Collections.emptyList(),
                                                           new byte[0],
-                                                          "xml");
+                                                          fileExtension);
         ResponseEntity responseEntity = rawObjectResponseCreator.createRawObjectResponse(rawObject);
         assertThat(responseEntity).isNotNull();
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -82,7 +83,7 @@ public class RawObjectResponseCreatorTest {
                                                           "commit message",
                                                           Collections.emptyList(),
                                                           new byte[0],
-                                                          "xml");
+                                                          null);
         ResponseEntity responseEntity = rawObjectResponseCreator.createRawObjectResponse(rawObject);
         assertThat(responseEntity).isNotNull();
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -93,9 +94,10 @@ public class RawObjectResponseCreatorTest {
     }
 
     @Test
-    public void testCreateRawObjectResponseWorkflowKindWithExtension() {
-        String objectName = "object name.xml";
-        String contentDispositionFileName = "attachment; filename=\"" + objectName + "\"";
+    public void testCreateRawObjectResponseWorkflowKindWithExtensionInName() {
+        String objectName = "object name.json";
+        String contentDispositionFileName = "attachment; filename=\"" + objectName +
+                                            RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
                                                           "workflow/specific-workflow-kind",


### PR DESCRIPTION
During creating new object in catalog it will be saved the extension of filename. This extension will in metadata of catalog object. The extension will be added to filename during getting a raw object or zip archive of multiple objects