### PR TITLE
Fix #140 by providing a new dialect for MySQL and MariaDB

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/util/ProActiveMySQL5InnoDBDialect.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/ProActiveMySQL5InnoDBDialect.java
@@ -1,0 +1,42 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.util;
+
+import org.hibernate.dialect.MySQL5InnoDBDialect;
+
+
+/**
+ * This class is to be used with MySQL or MariaDB to allow full utf-8 support.
+ *
+ * @author ActiveEon Team
+ * @since 27/08/18
+ */
+public class ProActiveMySQL5InnoDBDialect extends MySQL5InnoDBDialect {
+    @Override
+    public String getTableTypeString() {
+        return " ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,9 +8,20 @@ logging.level.org.springframework.web=info
 server.compression.enabled=true
 server.contextPath=/
 
-# DataSource settings: set here your own configurations for the database connection.
+##############
+# DATASOURCE #
+##############
+
+# The default settings are using hsqldb
 #spring.datasource.driverClassName=org.hsqldb.jdbc.JDBCDriver
-#spring.datasource.url=jdbc:hsqldb:file:/tmp/proactive/catalogObject-catalog;create=true;hsqldb.tx=mvcc;hsqldb.applog=1;hsqldb.sqllog=0;hsqldb.write_delay=false
+#spring.datasource.url=jdbc:hsqldb:file:/tmp/proactive/catalog;create=true;hsqldb.tx=mvcc;hsqldb.applog=1;hsqldb.sqllog=0;hsqldb.write_delay=false
+
+# For MariaDB/MySQL use the following settings
+# note the ProActiveMySQL5InnoDBDialect class that enforces the utf8mb4 charset
+#spring.datasource.driverClassName=org.mariadb.jdbc.Driver
+#spring.jpa.database-platform=org.ow2.proactive.catalog.util.ProActiveMySQL5InnoDBDialect
+#spring.datasource.url=jdbc:mariadb://localhost:3306/catalog
+
 #spring.datasource.username=root
 #spring.datasource.password=
 


### PR DESCRIPTION
This is intended to fix #140.

The properties file now contains comments to explain how to use MySQL or MariaDB without problems.
We extend the regular MySQL5InnoDBDialect to enforce the usage of the UTF-8 charset.
I've used the `utf8mb4` instead of `utf8` because of [that](https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434).
I believe our Hibernate version doesn't allow for characters encoding modification, as it will always rely on the default charset defined server-side.