### PR TITLE
Add getDependencies endpoint

### DIFF
--- a/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ow2.proactive.catalog.IntegrationTestConfig;
 import org.ow2.proactive.catalog.dto.BucketMetadata;
-import org.ow2.proactive.catalog.dto.CatalogObjectDependencyList;
+import org.ow2.proactive.catalog.dto.CatalogObjectDependencies;
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
 import org.ow2.proactive.catalog.dto.CatalogRawObject;
 import org.ow2.proactive.catalog.dto.DependsOnCatalogObject;
@@ -188,9 +188,9 @@ public class CatalogObjectServiceIntegrationTest {
                                                              .atZone(ZoneId.systemDefault())
                                                              .toInstant()
                                                              .toEpochMilli();
-        CatalogObjectDependencyList catalogObjectDependencyListOfAObjectFirstCommit = catalogObjectService.getObjectDependencies(bucketName,
-                                                                                                                                 aObject,
-                                                                                                                                 firstCommitTimeDependsOn);
+        CatalogObjectDependencies catalogObjectDependencyListOfAObjectFirstCommit = catalogObjectService.getObjectDependencies(bucketName,
+                                                                                                                               aObject,
+                                                                                                                               firstCommitTimeDependsOn);
         List<String> BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit = catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
                                                                                                                                  .stream()
                                                                                                                                  .map(DependsOnCatalogObject::getBucketAndObjectName)
@@ -209,8 +209,8 @@ public class CatalogObjectServiceIntegrationTest {
                                                          IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model.xml"));
 
         //if no revision number is specified, get ObjectDependencyList of the  last revision of the given object
-        CatalogObjectDependencyList catalogObjectDependencyListOfAObjectSecondCommit = catalogObjectService.getObjectDependencies(bucketName,
-                                                                                                                                  aObject);
+        CatalogObjectDependencies catalogObjectDependencyListOfAObjectSecondCommit = catalogObjectService.getObjectDependencies(bucketName,
+                                                                                                                                aObject);
         List<String> BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit = catalogObjectDependencyListOfAObjectSecondCommit.getDependsOnList()
                                                                                                                                    .stream()
                                                                                                                                    .map(DependsOnCatalogObject::getBucketAndObjectName)
@@ -234,8 +234,8 @@ public class CatalogObjectServiceIntegrationTest {
                                                  IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-2.xml"),
                                                  null);
 
-        CatalogObjectDependencyList catalogObjectDependencyListOfBObject = catalogObjectService.getObjectDependencies(bucketName,
-                                                                                                                      bObject);
+        CatalogObjectDependencies catalogObjectDependencyListOfBObject = catalogObjectService.getObjectDependencies(bucketName,
+                                                                                                                    bObject);
         List<String> BucketAndObjectNameDependsOnListOfBObjectFromDB = catalogObjectDependencyListOfBObject.getDependsOnList()
                                                                                                            .stream()
                                                                                                            .map(DependsOnCatalogObject::getBucketAndObjectName)
@@ -301,9 +301,9 @@ public class CatalogObjectServiceIntegrationTest {
                                                                                     .toInstant()
                                                                                     .toEpochMilli();
 
-        //Retrieve the CatalogObjectDependencyList of the bucket/A_Object
-        CatalogObjectDependencyList catalogObjectDependencyListOfAObjectFirstCommit = catalogObjectService.getObjectDependencies(bucketName,
-                                                                                                                                 aObject);
+        //Retrieve the CatalogObjectDependencies of the bucket/A_Object
+        CatalogObjectDependencies catalogObjectDependencyListOfAObjectFirstCommit = catalogObjectService.getObjectDependencies(bucketName,
+                                                                                                                               aObject);
         List<String> BucketAndObjectNameDependsOnListOfAObjectFromDB = catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
                                                                                                                       .stream()
                                                                                                                       .map(DependsOnCatalogObject::getBucketAndObjectName)
@@ -360,9 +360,9 @@ public class CatalogObjectServiceIntegrationTest {
         //Check that depends on list of the second commit contains only bucket/D_Object and bucket/E_Object and its size is equals to 2
         //Note that if the revision number is not specified, getObjectDependencies method processes the last revision of the given catalog object
 
-        CatalogObjectDependencyList catalogObjectDependencyListOfAObjectSecondCommit = catalogObjectService.getObjectDependencies(bucketName,
-                                                                                                                                  aObject,
-                                                                                                                                  secondCommitTimeOfAObject);
+        CatalogObjectDependencies catalogObjectDependencyListOfAObjectSecondCommit = catalogObjectService.getObjectDependencies(bucketName,
+                                                                                                                                aObject,
+                                                                                                                                secondCommitTimeOfAObject);
         List<String> BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit = catalogObjectDependencyListOfAObjectSecondCommit.getDependsOnList()
                                                                                                                                    .stream()
                                                                                                                                    .map(DependsOnCatalogObject::getBucketAndObjectName)
@@ -376,13 +376,13 @@ public class CatalogObjectServiceIntegrationTest {
 
         //Check that bucket/B_Object and bucket/C_Object workflows are not called by the bucket/A_Object anymore (here the version is not considered)
         //First we check the bucket/B_Object
-        CatalogObjectDependencyList catalogObjectDependencyListOfBObject = catalogObjectService.getObjectDependencies(bucketName,
-                                                                                                                      bObject);
+        CatalogObjectDependencies catalogObjectDependencyListOfBObject = catalogObjectService.getObjectDependencies(bucketName,
+                                                                                                                    bObject);
         assertThat(catalogObjectDependencyListOfBObject.getCalledByList()).hasSize(0);
 
         //Second we check the bucket/C_Object
-        CatalogObjectDependencyList catalogObjectDependencyListOfCObject = catalogObjectService.getObjectDependencies(bucketName,
-                                                                                                                      bObject);
+        CatalogObjectDependencies catalogObjectDependencyListOfCObject = catalogObjectService.getObjectDependencies(bucketName,
+                                                                                                                    bObject);
         assertThat(catalogObjectDependencyListOfCObject.getCalledByList()).hasSize(0);
 
         /************ THIRD TEST ****************/
@@ -440,9 +440,9 @@ public class CatalogObjectServiceIntegrationTest {
                                         .map(Metadata::getValue)
                                         .collect(Collectors.toList())).contains("1551960076669");
 
-        CatalogObjectDependencyList catalogObjectDependencyListOfAObjectThirdCommit = catalogObjectService.getObjectDependencies(bucketName,
-                                                                                                                                 aObject,
-                                                                                                                                 thirdCommitTimeOfAObject);
+        CatalogObjectDependencies catalogObjectDependencyListOfAObjectThirdCommit = catalogObjectService.getObjectDependencies(bucketName,
+                                                                                                                               aObject,
+                                                                                                                               thirdCommitTimeOfAObject);
 
         //check that bucket/D_Object/1551960076669 object is not in the catalog DB which means that isInCatalog=False
         assertFalse(catalogObjectDependencyListOfAObjectThirdCommit.getDependsOnList()

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectDependencies.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectDependencies.java
@@ -39,10 +39,10 @@ import lombok.Data;
 public class CatalogObjectDependencies {
 
     @JsonProperty("depends_on")
-    private List<DependsOnCatalogObject> dependsOnList;
+    private final List<DependsOnCatalogObject> dependsOnList;
 
     @JsonProperty("called_by")
-    private List<String> calledByList;
+    private final List<String> calledByList;
 
     public CatalogObjectDependencies(List<DependsOnCatalogObject> dependsOnList, List<String> calledByList) {
         this.dependsOnList = dependsOnList;

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectDependencies.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectDependencies.java
@@ -36,7 +36,7 @@ import lombok.Data;
  * @author ActiveEon Team
  */
 @Data
-public class CatalogObjectDependencyList {
+public class CatalogObjectDependencies {
 
     @JsonProperty("depends_on")
     private List<DependsOnCatalogObject> dependsOnList;
@@ -44,7 +44,7 @@ public class CatalogObjectDependencyList {
     @JsonProperty("called_by")
     private List<String> calledByList;
 
-    public CatalogObjectDependencyList(List<DependsOnCatalogObject> dependsOnList, List<String> calledByList) {
+    public CatalogObjectDependencies(List<DependsOnCatalogObject> dependsOnList, List<String> calledByList) {
         this.dependsOnList = dependsOnList;
         this.calledByList = calledByList;
     }

--- a/src/main/java/org/ow2/proactive/catalog/dto/DependsOnCatalogObject.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/DependsOnCatalogObject.java
@@ -39,14 +39,18 @@ import lombok.Data;
 public class DependsOnCatalogObject {
 
     @JsonProperty("bucket_and_object_name")
-    private String bucketAndObjectName;
+    private final String bucketAndObjectName;
+
+    @JsonProperty("revision_commit_time")
+    private final String revisionCommitTime;
 
     @JsonProperty("is_in_catalog")
-    private boolean isInCatalog;
+    private final boolean isInCatalog;
 
-    public DependsOnCatalogObject(String bucketAndObjectName, boolean isInCatalog) {
+    public DependsOnCatalogObject(String bucketAndObjectName, String revisionCommitTime, boolean isInCatalog) {
         this.bucketAndObjectName = bucketAndObjectName;
         this.isInCatalog = isInCatalog;
+        this.revisionCommitTime = revisionCommitTime;
     }
 
     public String getBucketAndObjectName() {

--- a/src/main/java/org/ow2/proactive/catalog/dto/DependsOnCatalogObject.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/DependsOnCatalogObject.java
@@ -38,10 +38,10 @@ import lombok.Data;
 @Data
 public class DependsOnCatalogObject {
 
-    @JsonProperty
+    @JsonProperty("bucket_and_object_name")
     private String bucketAndObjectName;
 
-    @JsonProperty
+    @JsonProperty("is_in_catalog")
     private boolean isInCatalog;
 
     public DependsOnCatalogObject(String bucketAndObjectName, boolean isInCatalog) {

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FilenameUtils;
+import org.ow2.proactive.catalog.dto.CatalogObjectDependencies;
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadataList;
 import org.ow2.proactive.catalog.dto.CatalogRawObject;
@@ -216,6 +217,24 @@ public class CatalogObjectController {
         CatalogRawObject rawObject = catalogObjectService.getCatalogRawObject(bucketName, name);
         return rawObjectResponseCreator.createRawObjectResponse(rawObject);
 
+    }
+
+    @ApiOperation(value = "Gets dependencies (dependsOn and calledBy) of a catalog object")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
+                            @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"),
+                            @ApiResponse(code = 404, message = "Bucket, catalog object or catalog object revision not found") })
+
+    @RequestMapping(value = REQUEST_API_QUERY + "/{name:.+}/dependencies", method = GET, produces = "application/json")
+    public CatalogObjectDependencies getDependencies(
+            @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
+            @PathVariable String bucketName, @PathVariable String name)
+            throws UnsupportedEncodingException, NotAuthenticatedException, AccessDeniedException {
+        restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionIdRequired,
+                                                                               sessionId,
+                                                                               bucketName);
+
+        return catalogObjectService.getObjectDependencies(bucketName, name);
     }
 
     @ApiOperation(value = "Lists catalog objects metadata", notes = "Returns catalog objects metadata associated to the latest revision.")

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -44,7 +44,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AutoDetectParser;
-import org.ow2.proactive.catalog.dto.CatalogObjectDependencyList;
+import org.ow2.proactive.catalog.dto.CatalogObjectDependencies;
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
 import org.ow2.proactive.catalog.dto.CatalogRawObject;
 import org.ow2.proactive.catalog.dto.DependsOnCatalogObject;
@@ -247,10 +247,10 @@ public class CatalogObjectService {
      * @param bucketName
      * @param name
      * @param revisionCommitTime
-     * @return CatalogObjectDependencyList composed of two list of dependencies dependsOn and calledBy
+     * @return the dependencies (dependsOn and calledBy) of a catalog object
      */
 
-    protected CatalogObjectDependencyList processObjectDependencies(String bucketName, String name,
+    protected CatalogObjectDependencies processObjectDependencies(String bucketName, String name,
             long revisionCommitTime) {
         List<String> dependsOnCatalogObjectsList = catalogObjectRevisionRepository.findDependsOnCatalogObjectNamesFromKeyValueMetadata(bucketName,
                                                                                                                                        name,
@@ -280,7 +280,7 @@ public class CatalogObjectService {
                                                                                                                                                              .getName()))
                                                                                 .collect(Collectors.toList());
 
-        return new CatalogObjectDependencyList(dependsOnBucketAndObjectNameList, calledByBucketAndObjectNameList);
+        return new CatalogObjectDependencies(dependsOnBucketAndObjectNameList, calledByBucketAndObjectNameList);
     }
 
     private boolean isDependsOnObjectExistInCatalog(String bucketName, String name,
@@ -303,16 +303,16 @@ public class CatalogObjectService {
      * @param bucketName
      * @param name
      * @param revisionCommitTime
-     * @return  CatalogObjectDependencyList composed of two list of dependencies: dependsOn and calledBy
+     * @return  the dependencies (dependsOn and calledBy) of a catalog object
      */
 
-    public CatalogObjectDependencyList getObjectDependencies(String bucketName, String name, long revisionCommitTime) {
+    public CatalogObjectDependencies getObjectDependencies(String bucketName, String name, long revisionCommitTime) {
         // Check that the bucketName/name object exists in the catalog
         findCatalogObjectByNameAndBucketAndCheck(bucketName, name);
         return processObjectDependencies(bucketName, name, revisionCommitTime);
     }
 
-    public CatalogObjectDependencyList getObjectDependencies(String bucketName, String name) {
+    public CatalogObjectDependencies getObjectDependencies(String bucketName, String name) {
         // Check that the bucketName/name object exists in the catalog and retrieve the commit time
         CatalogObjectRevisionEntity catalogObject = findCatalogObjectByNameAndBucketAndCheck(bucketName, name);
         return processObjectDependencies(bucketName, name, catalogObject.getCommitTime());

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -262,6 +262,7 @@ public class CatalogObjectService {
                                                                                                                                                   revisionCommitTime,
                                                                                                                                                   dependOnCatalogObject);
             dependsOnBucketAndObjectNameList.add(new DependsOnCatalogObject(dependOnCatalogObject,
+                                                                            String.valueOf(revisionCommitTime),
                                                                             isDependsOnObjectExistInCatalog(separatorUtility.getSplitBySeparator(dependOnCatalogObject)
                                                                                                                             .get(0),
                                                                                                             separatorUtility.getSplitBySeparator(dependOnCatalogObject)


### PR DESCRIPTION
In this PR, we add a new endpoint `getDependencies` that returns dependencies (dependsOn and calledBy) of a given catalog object. 