### PR TITLE
Fix PA + Oracle bug when loading catalog objects

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/repository/BucketRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/BucketRepository.java
@@ -62,12 +62,12 @@ public interface BucketRepository extends JpaRepository<BucketEntity, Long>, Jpa
     @Query(value = "SELECT bk FROM BucketEntity bk WHERE bk.bucketName = ?1")
     BucketEntity findBucketForUpdate(String bucketName);
 
-    @Query(value = "SELECT DISTINCT bk, COUNT(cos.id.name) as objectCount FROM BucketEntity bk LEFT JOIN bk.catalogObjects cos" +
+    @Query(value = "SELECT bk, COUNT(cos.id.name) as objectCount FROM BucketEntity bk LEFT JOIN bk.catalogObjects cos" +
                    " WHERE lower(cos.kind) LIKE lower(concat(?1, '%')) AND lower(cos.contentType) LIKE lower(concat(?2, '%'))" +
                    " AND lower(cos.id.name) LIKE lower(concat('%', ?3, '%')) OR bk.catalogObjects IS EMPTY GROUP BY bk")
     List<Object[]> findContainingKindAndContentTypeAndObjectName(String kind, String contentType, String objectName);
 
-    @Query(value = "SELECT DISTINCT bk, COUNT(cos.id.name) as objectCount FROM BucketEntity bk LEFT JOIN bk.catalogObjects cos" +
+    @Query(value = "SELECT bk, COUNT(cos.id.name) as objectCount FROM BucketEntity bk LEFT JOIN bk.catalogObjects cos" +
                    " WHERE bk.owner in ?1 AND (lower(cos.kind) LIKE lower(concat(?2, '%'))" +
                    " AND (lower(cos.contentType) LIKE lower(concat(?3, '%')) AND lower(cos.id.name) LIKE lower(concat('%', ?4, '%')))" +
                    " OR bk.catalogObjects IS EMPTY) GROUP BY bk")


### PR DESCRIPTION
This PR is to fix the PA + Oracle bug showed below when loading catalog objects. Actually, DISCTINCT is useless when GROUP BY is used and causes issues querying the DB.
`oracle.jdbc.OracleDatabaseException: ORA-00979: not a GROUP BY expression`
