### PR TITLE
Restrict the object naming

### DIFF
--- a/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
@@ -56,6 +56,7 @@ import org.ow2.proactive.catalog.util.RevisionCommitMessageBuilder;
 import org.ow2.proactive.catalog.util.SeparatorUtility;
 import org.ow2.proactive.catalog.util.name.validator.BucketNameValidator;
 import org.ow2.proactive.catalog.util.name.validator.KindAndContentTypeValidator;
+import org.ow2.proactive.catalog.util.name.validator.ObjectNameValidator;
 import org.ow2.proactive.catalog.util.parser.AbstractCatalogObjectParser;
 import org.ow2.proactive.catalog.util.parser.CalendarDefinitionParser;
 import org.ow2.proactive.catalog.util.parser.InfrastructureParser;
@@ -267,6 +268,11 @@ public class IntegrationTestConfig {
     @Bean
     public KindAndContentTypeValidator kindNameValidator() {
         return new KindAndContentTypeValidator();
+    }
+
+    @Bean
+    public ObjectNameValidator objectNameValidator() {
+        return new ObjectNameValidator();
     }
 
     @Bean

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -51,10 +51,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ow2.proactive.catalog.Application;
 import org.ow2.proactive.catalog.dto.BucketMetadata;
-import org.ow2.proactive.catalog.service.exception.BucketNotFoundException;
-import org.ow2.proactive.catalog.service.exception.CatalogObjectAlreadyExistingException;
-import org.ow2.proactive.catalog.service.exception.CatalogObjectNotFoundException;
-import org.ow2.proactive.catalog.service.exception.KindOrContentTypeIsNotValidException;
+import org.ow2.proactive.catalog.service.exception.*;
 import org.ow2.proactive.catalog.util.IntegrationTestUtil;
 import org.ow2.proactive.catalog.util.parser.SupportedParserKinds;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -316,6 +313,23 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body(ERROR_MESSAGE,
                      equalTo(new KindOrContentTypeIsNotValidException(wrongContentType,
                                                                       "Content-Type").getLocalizedMessage()));
+    }
+
+    @Test
+    public void testCreateObjectWrongName() {
+        String wrongName = "app/json-/";
+        given().header("sessionID", "12345")
+               .pathParam("bucketName", bucket.getName())
+               .queryParam("kind", "workflow/pca")
+               .queryParam("name", wrongName)
+               .queryParam("commitMessage", "commit message")
+               .queryParam("objectContentType", "application/json")
+               .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
+               .when()
+               .post(CATALOG_OBJECTS_RESOURCE)
+               .then()
+               .statusCode(HttpStatus.SC_BAD_REQUEST)
+               .body(ERROR_MESSAGE, equalTo(new ObjectNameIsNotValidException(wrongName).getLocalizedMessage()));
     }
 
     @Test

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -60,13 +60,7 @@ import org.ow2.proactive.catalog.repository.entity.BucketEntity;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectEntity;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
 import org.ow2.proactive.catalog.repository.entity.KeyValueLabelMetadataEntity;
-import org.ow2.proactive.catalog.service.exception.BucketNotFoundException;
-import org.ow2.proactive.catalog.service.exception.CatalogObjectAlreadyExistingException;
-import org.ow2.proactive.catalog.service.exception.CatalogObjectNotFoundException;
-import org.ow2.proactive.catalog.service.exception.KindOrContentTypeIsNotValidException;
-import org.ow2.proactive.catalog.service.exception.RevisionNotFoundException;
-import org.ow2.proactive.catalog.service.exception.UnprocessableEntityException;
-import org.ow2.proactive.catalog.service.exception.WrongParametersException;
+import org.ow2.proactive.catalog.service.exception.*;
 import org.ow2.proactive.catalog.service.model.GenericInfoBucketData;
 import org.ow2.proactive.catalog.util.ArchiveManagerHelper;
 import org.ow2.proactive.catalog.util.ArchiveManagerHelper.FileNameAndContent;
@@ -74,6 +68,7 @@ import org.ow2.proactive.catalog.util.ArchiveManagerHelper.ZipArchiveContent;
 import org.ow2.proactive.catalog.util.RevisionCommitMessageBuilder;
 import org.ow2.proactive.catalog.util.SeparatorUtility;
 import org.ow2.proactive.catalog.util.name.validator.KindAndContentTypeValidator;
+import org.ow2.proactive.catalog.util.name.validator.ObjectNameValidator;
 import org.ow2.proactive.catalog.util.parser.WorkflowParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -117,6 +112,9 @@ public class CatalogObjectService {
 
     @Autowired
     private KindAndContentTypeValidator kindAndContentTypeValidator;
+
+    @Autowired
+    private ObjectNameValidator objectNameValidator;
 
     @Autowired
     private RestApiAccessService restApiAccessService;
@@ -182,6 +180,9 @@ public class CatalogObjectService {
 
     public CatalogObjectMetadata createCatalogObject(String bucketName, String name, String kind, String commitMessage,
             String username, String contentType, List<Metadata> metadataList, byte[] rawObject, String extension) {
+        if (!objectNameValidator.isValid(name)) {
+            throw new ObjectNameIsNotValidException(name);
+        }
         if (!kindAndContentTypeValidator.isValid(kind)) {
             throw new KindOrContentTypeIsNotValidException(kind, "kind");
         }

--- a/src/main/java/org/ow2/proactive/catalog/service/exception/ObjectNameIsNotValidException.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/exception/ObjectNameIsNotValidException.java
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * This Exception is thrown when a CREATE request for object has been
  * received but the object name is not valid, according to next rules:
  * tthe object name should not be empty, should start and finish with non-whitespace character
- * and can contain all characters except forward slash.
+ * and can contain all characters except forward slash and comma.
  * The HTTP status is 400, "Bad Request"
  *
  * @author ActiveEon Team
@@ -44,7 +44,7 @@ public class ObjectNameIsNotValidException extends ClientException {
 
     public ObjectNameIsNotValidException(String objectName) {
         super("The object name: '" + objectName + "' is not valid. " +
-              "\n The object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash.");
+              "\n The object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash and comma.");
     }
 
     public ObjectNameIsNotValidException(Throwable cause) {

--- a/src/main/java/org/ow2/proactive/catalog/service/exception/ObjectNameIsNotValidException.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/exception/ObjectNameIsNotValidException.java
@@ -1,0 +1,54 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service.exception;
+
+import org.ow2.proactive.microservices.common.exception.ClientException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+
+/**
+ * This Exception is thrown when a CREATE request for object has been
+ * received but the object name is not valid, according to next rules:
+ * tthe object name should not be empty, should start and finish with non-whitespace character
+ * and can contain all characters except forward slash.
+ * The HTTP status is 400, "Bad Request"
+ *
+ * @author ActiveEon Team
+ */
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class ObjectNameIsNotValidException extends ClientException {
+
+    public ObjectNameIsNotValidException(String objectName) {
+        super("The object name: '" + objectName + "' is not valid. " +
+              "\n The object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash.");
+    }
+
+    public ObjectNameIsNotValidException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidator.java
@@ -4,7 +4,7 @@
  * Workflows & Scheduling, Orchestration, Cloud Automation
  * and Big Data Analysis on Enterprise Grids & Clouds.
  *
- * Copyright (c) 2007 - 2020 ActiveEon
+ * Copyright (c) 2007 - 2017 ActiveEon
  * Contact: contact@activeeon.com
  *
  * This library is free software: you can redistribute it and/or
@@ -29,11 +29,11 @@ import org.springframework.stereotype.Component;
 
 
 /**
- * According to this validator: the object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash and ';'.
+ * According to this validator: the object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash.
  */
 @Component
 public class ObjectNameValidator extends NameValidator {
-    protected static final String VALID_OBJECT_NAME_PATTERN = "^[^\\s^\\/^;]+(\\s+[^\\s^\\/^;]+)*$";
+    protected static final String VALID_OBJECT_NAME_PATTERN = "^[^\\s\\/]+(\\s+[^\\s\\/]+)*$";
 
     public ObjectNameValidator() {
         super(VALID_OBJECT_NAME_PATTERN);

--- a/src/main/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidator.java
@@ -29,11 +29,11 @@ import org.springframework.stereotype.Component;
 
 
 /**
- * According to this validator: the object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash.
+ * According to this validator: the object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash and comma.
  */
 @Component
 public class ObjectNameValidator extends NameValidator {
-    protected static final String VALID_OBJECT_NAME_PATTERN = "^[^\\s\\/]+(\\s+[^\\s\\/]+)*$";
+    protected static final String VALID_OBJECT_NAME_PATTERN = "^[^\\s\\/,]+(\\s+[^\\s\\/,]+)*$";
 
     public ObjectNameValidator() {
         super(VALID_OBJECT_NAME_PATTERN);

--- a/src/main/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidator.java
@@ -1,0 +1,41 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2020 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.util.name.validator;
+
+import org.springframework.stereotype.Component;
+
+
+/**
+ * According to this validator: the object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash and ';'.
+ */
+@Component
+public class ObjectNameValidator extends NameValidator {
+    protected static final String VALID_OBJECT_NAME_PATTERN = "^[^\\s^\\/^;]+(\\s+[^\\s^\\/^;]+)*$";
+
+    public ObjectNameValidator() {
+        super(VALID_OBJECT_NAME_PATTERN);
+    }
+}

--- a/src/test/java/org/ow2/proactive/catalog/util/name/validator/BucketNameValidatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/name/validator/BucketNameValidatorTest.java
@@ -23,7 +23,7 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package org.ow2.proactive.catalog.util;
+package org.ow2.proactive.catalog.util.name.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/src/test/java/org/ow2/proactive/catalog/util/name/validator/KindAndContentTypeValidatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/name/validator/KindAndContentTypeValidatorTest.java
@@ -23,7 +23,7 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package org.ow2.proactive.catalog.util;
+package org.ow2.proactive.catalog.util.name.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/src/test/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidatorTest.java
@@ -96,12 +96,12 @@ public class ObjectNameValidatorTest {
     public void testCheckObjectNameWithSpecialSymbols() {
         assertThat(objectNameValidator.isValid("name&test#'%new")).isTrue();
         assertThat(objectNameValidator.isValid("name${v}")).isTrue();
-        assertThat(objectNameValidator.isValid("?,.:+=%``")).isTrue();
+        assertThat(objectNameValidator.isValid("?.:+=%``")).isTrue();
         assertThat(objectNameValidator.isValid("$*^¨_-°")).isTrue();
         assertThat(objectNameValidator.isValid(")@#&é\\'")).isTrue();
-        assertThat(objectNameValidator.isValid("?,.:+=%``$*^¨_-°)@#&é\\';")).isTrue();
-        assertThat(objectNameValidator.isValid("[$&+,:;=?@#|'<>.-^*()%!]\"{}§è!à")).isTrue();
-        assertThat(objectNameValidator.isValid("workflow$with&specific&symbols+in name:$&%[$&+,:;=?@#|'<>.-^*()%!]\"{}§è!à ae.extension")).isTrue();
+        assertThat(objectNameValidator.isValid("?.:+=%``$*^¨_-°)@#&é\\';")).isTrue();
+        assertThat(objectNameValidator.isValid("[$&+:;=?@#|'<>.-^*()%!]\"{}§è!à")).isTrue();
+        assertThat(objectNameValidator.isValid("workflow$with&specific&symbols+in name:$&%[$&+:;=?@#|'<>.-^*()%!]\"{}§è!à ae.extension")).isTrue();
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidatorTest.java
@@ -114,10 +114,10 @@ public class ObjectNameValidatorTest {
     }
 
     @Test
-    public void testCheckObjectNameWithSemicolonSymbols() {
-        assertThat(objectNameValidator.isValid("name;new;y")).isTrue();
-        assertThat(objectNameValidator.isValid("name;")).isTrue();
-        assertThat(objectNameValidator.isValid(";name")).isTrue();
-        assertThat(objectNameValidator.isValid(";")).isTrue();
+    public void testCheckObjectNameWithCommaSymbols() {
+        assertThat(objectNameValidator.isValid("name,new,y")).isFalse();
+        assertThat(objectNameValidator.isValid("name,")).isFalse();
+        assertThat(objectNameValidator.isValid(",name")).isFalse();
+        assertThat(objectNameValidator.isValid(",")).isFalse();
     }
 }

--- a/src/test/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidatorTest.java
@@ -1,0 +1,122 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.util.name.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 17/04/2020
+ */
+public class ObjectNameValidatorTest {
+
+    private ObjectNameValidator objectNameValidator = new ObjectNameValidator();
+
+    @Test
+    public void testCheckObjectNameValid() {
+        assertThat(objectNameValidator.isValid("valid-name-1")).isTrue();
+        assertThat(objectNameValidator.isValid("name-name")).isTrue();
+        assertThat(objectNameValidator.isValid("name name")).isTrue();
+    }
+
+    @Test
+    public void testCheckObjectNameStartWithNumber() {
+        assertThat(objectNameValidator.isValid("1-name")).isTrue();
+    }
+
+    @Test
+    public void testCheckObjectNameOnlyNumbers() {
+        assertThat(objectNameValidator.isValid("123")).isTrue();
+    }
+
+    @Test
+    public void testCheckObjectNameWithCapitals() {
+        assertThat(objectNameValidator.isValid("nameWithCapitals")).isTrue();
+        assertThat(objectNameValidator.isValid("NAME")).isTrue();
+    }
+
+    @Test
+    public void testCheckObjectNameDashInEnd() {
+        assertThat(objectNameValidator.isValid("name-")).isTrue();
+        assertThat(objectNameValidator.isValid("-name")).isTrue();
+    }
+
+    @Test
+    public void testCheckObjectNameSmallLength() {
+        assertThat(objectNameValidator.isValid("bu")).isTrue();
+        assertThat(objectNameValidator.isValid("a")).isTrue();
+    }
+
+    @Test
+    public void testCheckObjectNameWithDot() {
+        assertThat(objectNameValidator.isValid("name.my")).isTrue();
+    }
+
+    @Test
+    public void testCheckObjectEmptyName() {
+        assertThat(objectNameValidator.isValid("")).isFalse();
+    }
+
+    @Test
+    public void testCheckObjectNameWithSpace() {
+        assertThat(objectNameValidator.isValid("name space")).isTrue();
+        assertThat(objectNameValidator.isValid("  ")).isFalse();
+        assertThat(objectNameValidator.isValid("  name space before")).isFalse();
+        assertThat(objectNameValidator.isValid("name space after   ")).isFalse();
+        assertThat(objectNameValidator.isValid(" beforeANDafter   ")).isFalse();
+    }
+
+    @Test
+    public void testCheckObjectNameWithSpecialSymbols() {
+        assertThat(objectNameValidator.isValid("name&test#'%new")).isTrue();
+        assertThat(objectNameValidator.isValid("name${v}")).isTrue();
+        assertThat(objectNameValidator.isValid("?,.:+=%``")).isTrue();
+        assertThat(objectNameValidator.isValid("$*^¨_-°")).isTrue();
+        assertThat(objectNameValidator.isValid(")@#&é\\'")).isTrue();
+        assertThat(objectNameValidator.isValid("?,.:+=%``$*^¨_-°)@#&é\\';")).isTrue();
+        assertThat(objectNameValidator.isValid("[$&+,:;=?@#|'<>.-^*()%!]\"{}§è!à")).isTrue();
+    }
+
+    @Test
+    public void testCheckObjectNameWithForwardSlashSymbols() {
+        assertThat(objectNameValidator.isValid("name/new/my")).isFalse();
+        assertThat(objectNameValidator.isValid("name new/my")).isFalse();
+        assertThat(objectNameValidator.isValid("name/")).isFalse();
+        assertThat(objectNameValidator.isValid("/name")).isFalse();
+        assertThat(objectNameValidator.isValid("/")).isFalse();
+    }
+
+    @Test
+    public void testCheckObjectNameWithSemicolonSymbols() {
+        assertThat(objectNameValidator.isValid("name;new;y")).isTrue();
+        assertThat(objectNameValidator.isValid("name;")).isTrue();
+        assertThat(objectNameValidator.isValid(";name")).isTrue();
+        assertThat(objectNameValidator.isValid(";")).isTrue();
+    }
+}

--- a/src/test/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidatorTest.java
@@ -101,6 +101,7 @@ public class ObjectNameValidatorTest {
         assertThat(objectNameValidator.isValid(")@#&é\\'")).isTrue();
         assertThat(objectNameValidator.isValid("?,.:+=%``$*^¨_-°)@#&é\\';")).isTrue();
         assertThat(objectNameValidator.isValid("[$&+,:;=?@#|'<>.-^*()%!]\"{}§è!à")).isTrue();
+        assertThat(objectNameValidator.isValid("workflow$with&specific&symbols+in name:$&%[$&+,:;=?@#|'<>.-^*()%!]\"{}§è!à ae.extension")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
The object name should not be empty, should start and finish with non-whitespace character and can contain all characters except forward slash and comma.