### PR TITLE
Add pagination mechanism to Catalog for higher efficiency at scale

### DIFF
--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/BucketControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/BucketControllerIntegrationTest.java
@@ -277,27 +277,30 @@ public class BucketControllerIntegrationTest extends AbstractRestAssuredTest {
 
         // Add an object of kind "my-object-kind" into specific bucket
         IntegrationTestUtil.postObjectToBucket(bucketIdWithMyObjects,
-                                               "MY-objecT-Kind",
                                                "myobjectname",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "MY-objecT-Kind",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         // Add an object of kind "my-object-general" into specific bucket
         IntegrationTestUtil.postObjectToBucket(bucketIdWithmyObjectsGeneral,
-                                               "My-oBJeCt-General",
                                                "myobjectname",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "My-oBJeCt-General",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         String bucketWithSomeObjectsId = IntegrationTestUtil.createBucket(bucketNameWithSomeObjects, "owner");
 
         IntegrationTestUtil.postObjectToBucket(bucketWithSomeObjectsId,
-                                               "differentkind",
                                                "myobjectname",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "differentkind",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         // list buckets by specific kind -> should return one specified bucket and empty bucket
@@ -333,24 +336,27 @@ public class BucketControllerIntegrationTest extends AbstractRestAssuredTest {
 
         // Add three objects to the first bucket
         IntegrationTestUtil.postObjectToBucket(bucketIdOfFirstBucket,
-                                               workflowKind,
                                                "object1",
-                                               "first commit",
-                                               MediaType.APPLICATION_ATOM_XML_VALUE,
-                                               IntegrationTestUtil.getWorkflowFile("workflow.xml"));
-
-        IntegrationTestUtil.postObjectToBucket(bucketIdOfFirstBucket,
+                                               "myobjectprojectname",
                                                workflowKind,
-                                               "object2",
-                                               "first commit",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         IntegrationTestUtil.postObjectToBucket(bucketIdOfFirstBucket,
-                                               pcaKind,
-                                               "abc",
-                                               "first commit",
+                                               "object2",
+                                               "myobjectprojectname",
+                                               workflowKind,
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
+                                               IntegrationTestUtil.getWorkflowFile("workflow.xml"));
+
+        IntegrationTestUtil.postObjectToBucket(bucketIdOfFirstBucket,
+                                               "abc",
+                                               "myobjectprojectname",
+                                               pcaKind,
+                                               MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         List<HashMap<String, Object>> bucketEntityWithContentCountList1 = given().param("contentType",
@@ -367,24 +373,27 @@ public class BucketControllerIntegrationTest extends AbstractRestAssuredTest {
 
         // Add three objects to the second bucket
         IntegrationTestUtil.postObjectToBucket(bucketIdOfSecondBucket,
-                                               workflowKind,
                                                "object-abc",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               workflowKind,
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         IntegrationTestUtil.postObjectToBucket(bucketIdOfSecondBucket,
-                                               ruleKind,
                                                "object2",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               ruleKind,
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         IntegrationTestUtil.postObjectToBucket(bucketIdOfSecondBucket,
-                                               ruleKind,
                                                "object3",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               ruleKind,
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         List<HashMap<String, Object>> bucketEntityWithContentCountList2 = given().param("contentType",
@@ -432,28 +441,31 @@ public class BucketControllerIntegrationTest extends AbstractRestAssuredTest {
 
         // Add an object of kind "my-object-kind" into specific bucket
         IntegrationTestUtil.postObjectToBucket(bucketIdWithMyObjects,
-                                               "MY-objecT-Kind",
                                                "my-object-name-1",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "MY-objecT-Kind",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         String bucketWithSomeObjectsId = IntegrationTestUtil.createBucket(bucketNameWithSomeObjects, "owner");
 
         IntegrationTestUtil.postObjectToBucket(bucketWithSomeObjectsId,
-                                               "differentkind",
                                                "my-object-name-2",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "differentkind",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         String bucketIdWithOtherObjects = IntegrationTestUtil.createBucket(bucketNameWithOtherObjects, "owner");
         // Add an object of kind "my-object-kind" into specific bucket
         IntegrationTestUtil.postObjectToBucket(bucketIdWithOtherObjects,
-                                               "MY-objecT-Kind",
                                                "other-names",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "MY-objecT-Kind",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         // list all buckets by any Name -> should return all buckets with empty bucket
@@ -546,25 +558,28 @@ public class BucketControllerIntegrationTest extends AbstractRestAssuredTest {
 
         IntegrationTestUtil.postDefaultWorkflowToBucket(bucketAdminOwnerWorkflowKindId);
         IntegrationTestUtil.postObjectToBucket(BucketAdminOwnerOtherKindId,
-                                               "other-kind",
                                                "my workflow",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "other-kind",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         IntegrationTestUtil.postDefaultWorkflowToBucket(BucketAdminOwnerMixedKindId);
         IntegrationTestUtil.postObjectToBucket(BucketAdminOwnerMixedKindId,
-                                               "other-kind",
                                                "other object",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "other-kind",
                                                MediaType.APPLICATION_ATOM_XML_VALUE,
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         IntegrationTestUtil.postObjectToBucket(BucketAdminOwnerMixedKindId,
-                                               "other-kind",
                                                "other new object",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "other-kind",
                                                "bucket-admin-owner-content-type",
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         IntegrationTestUtil.postObjectToBucket(BucketAdminOwnerMixedKindId,
@@ -574,10 +589,11 @@ public class BucketControllerIntegrationTest extends AbstractRestAssuredTest {
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         IntegrationTestUtil.postObjectToBucket(BucketAdminOwnerMixedKindId,
-                                               "new-kind-2",
                                                "other new object",
-                                               "first commit",
+                                               "myobjectprojectname",
+                                               "new-kind-2",
                                                "new-content-2",
+                                               "first commit",
                                                IntegrationTestUtil.getWorkflowFile("workflow.xml"));
 
         IntegrationTestUtil.postDefaultWorkflowToBucket(BucketUserOwnerWorkflowKindId);

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -716,8 +716,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
         String groovyContentType = "text/x-groovy";
 
         given().header("sessionID", "12345")
-               .header("kind", workflowKind)
-               .header("contentType", xmlContentType)
+               .queryParam("kind", workflowKind)
+               .queryParam("contentType", xmlContentType)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()
@@ -752,8 +752,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .statusCode(HttpStatus.SC_CREATED);
 
         given().header("sessionID", "12345")
-               .header("kind", workflowKind)
-               .header("contentType", xmlContentType)
+               .queryParam("kind", workflowKind)
+               .queryParam("contentType", xmlContentType)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()
@@ -762,8 +762,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("results.size()", equalTo(1));
 
         given().header("sessionID", "12345")
-               .header("kind", workflowKind)
-               .header("contentType", groovyContentType)
+               .queryParam("kind", workflowKind)
+               .queryParam("contentType", groovyContentType)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()
@@ -772,7 +772,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("results.size()", equalTo(1));
 
         given().header("sessionID", "12345")
-               .header("kind", workflowKind)
+               .queryParam("kind", workflowKind)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()
@@ -781,7 +781,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("results.size()", equalTo(2));
 
         given().header("sessionID", "12345")
-               .header("contentType", xmlContentType)
+               .queryParam("contentType", xmlContentType)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()
@@ -790,8 +790,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("results.size()", equalTo(2));
 
         given().header("sessionID", "12345")
-               .header("kind", pcaKind)
-               .header("contentType", xmlContentType)
+               .queryParam("kind", pcaKind)
+               .queryParam("contentType", xmlContentType)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()
@@ -840,8 +840,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .statusCode(HttpStatus.SC_CREATED);
 
         given().header("sessionID", "12345")
-               .header("kind", workflowKind)
-               .header("contentType", xmlContentType)
+               .queryParam("kind", workflowKind)
+               .queryParam("contentType", xmlContentType)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()
@@ -850,8 +850,8 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .body("results.size()", equalTo(2));
 
         given().header("sessionID", "12345")
-               .header("kind", scriptTaskKind)
-               .header("contentType", xmlContentType)
+               .queryParam("kind", scriptTaskKind)
+               .queryParam("contentType", xmlContentType)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()
@@ -872,7 +872,7 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .statusCode(HttpStatus.SC_CREATED);
 
         given().header("sessionID", "12345")
-               .header("contentType", groovyContentType)
+               .queryParam("contentType", groovyContentType)
                .when()
                .get(CATALOG_OBJECTS_REFERENCE)
                .then()

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/BucketServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/BucketServiceIntegrationTest.java
@@ -62,7 +62,7 @@ public class BucketServiceIntegrationTest {
 
     private List<Metadata> keyValues;
 
-    private static final String EMPTY_STRING = "";
+    private static final String PROJECT_NAME = "projectName";
 
     @Before
     public void createBucket() {
@@ -92,7 +92,7 @@ public class BucketServiceIntegrationTest {
         bucket = bucketService.createBucket("bucketnotempty", "emptyBucketTest");
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "object",
                                                  "commit message",
                                                  "username",
@@ -150,7 +150,7 @@ public class BucketServiceIntegrationTest {
         bucket = bucketService.createBucket("bucket-workflow", "owner");
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "WORKFLOW",
                                                  "commit message",
                                                  "username",
@@ -181,7 +181,7 @@ public class BucketServiceIntegrationTest {
         bucket = bucketService.createBucket("bucket-workflow", "owner");
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "Workflow",
                                                  "commit message",
                                                  "username",
@@ -194,7 +194,7 @@ public class BucketServiceIntegrationTest {
         BucketMetadata bucketWfStandard = bucketService.createBucket("bucket-wf-standard", "owner");
         catalogObjectService.createCatalogObject(bucketWfStandard.getName(),
                                                  "catalog",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "WorkFlow/Standard",
                                                  "commit message",
                                                  "username",
@@ -207,7 +207,7 @@ public class BucketServiceIntegrationTest {
         BucketMetadata bucketWfPCA = bucketService.createBucket("bucket-wf-pca", "owner");
         catalogObjectService.createCatalogObject(bucketWfPCA.getName(),
                                                  "catalog",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "workflow/PCA",
                                                  "commit message",
                                                  "username",
@@ -220,7 +220,7 @@ public class BucketServiceIntegrationTest {
         BucketMetadata bucketNotWf = bucketService.createBucket("bucket-not-workflow", "different-owner");
         catalogObjectService.createCatalogObject(bucketNotWf.getName(),
                                                  "catalog",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "not-workflow",
                                                  "commit message",
                                                  "username",

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/BucketServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/BucketServiceIntegrationTest.java
@@ -52,10 +52,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration(classes = { IntegrationTestConfig.class })
 public class BucketServiceIntegrationTest {
 
-    private static final String DEFAULT_OBJECTS_FOLDER = "/default-objects";
-
-    private static final String RAW_OBJECTS_FOLDER = "/raw-objects";
-
     @Autowired
     private BucketService bucketService;
 
@@ -65,6 +61,8 @@ public class BucketServiceIntegrationTest {
     private BucketMetadata bucket;
 
     private List<Metadata> keyValues;
+
+    private static final String EMPTY_STRING = "";
 
     @Before
     public void createBucket() {
@@ -94,6 +92,7 @@ public class BucketServiceIntegrationTest {
         bucket = bucketService.createBucket("bucketnotempty", "emptyBucketTest");
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog",
+                                                 EMPTY_STRING,
                                                  "object",
                                                  "commit message",
                                                  "username",
@@ -102,7 +101,7 @@ public class BucketServiceIntegrationTest {
                                                  null,
                                                  null);
 
-        BucketMetadata emptyBucket = bucketService.createBucket("bucketempty", "emptyBucketTest");
+        bucketService.createBucket("bucketempty", "emptyBucketTest");
 
         List<BucketMetadata> emptyBucketTest = bucketService.listBuckets("emptyBucketTest",
                                                                          Optional.empty(),
@@ -151,6 +150,7 @@ public class BucketServiceIntegrationTest {
         bucket = bucketService.createBucket("bucket-workflow", "owner");
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog",
+                                                 EMPTY_STRING,
                                                  "WORKFLOW",
                                                  "commit message",
                                                  "username",
@@ -181,6 +181,7 @@ public class BucketServiceIntegrationTest {
         bucket = bucketService.createBucket("bucket-workflow", "owner");
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog",
+                                                 EMPTY_STRING,
                                                  "Workflow",
                                                  "commit message",
                                                  "username",
@@ -193,6 +194,7 @@ public class BucketServiceIntegrationTest {
         BucketMetadata bucketWfStandard = bucketService.createBucket("bucket-wf-standard", "owner");
         catalogObjectService.createCatalogObject(bucketWfStandard.getName(),
                                                  "catalog",
+                                                 EMPTY_STRING,
                                                  "WorkFlow/Standard",
                                                  "commit message",
                                                  "username",
@@ -205,6 +207,7 @@ public class BucketServiceIntegrationTest {
         BucketMetadata bucketWfPCA = bucketService.createBucket("bucket-wf-pca", "owner");
         catalogObjectService.createCatalogObject(bucketWfPCA.getName(),
                                                  "catalog",
+                                                 EMPTY_STRING,
                                                  "workflow/PCA",
                                                  "commit message",
                                                  "username",
@@ -217,6 +220,7 @@ public class BucketServiceIntegrationTest {
         BucketMetadata bucketNotWf = bucketService.createBucket("bucket-not-workflow", "different-owner");
         catalogObjectService.createCatalogObject(bucketNotWf.getName(),
                                                  "catalog",
+                                                 EMPTY_STRING,
                                                  "not-workflow",
                                                  "commit message",
                                                  "username",

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
@@ -116,6 +116,7 @@ public class CatalogObjectServiceIntegrationTest {
         Thread.sleep(1); // to be sure that a new revision time will be different from previous revision time
         catalogObject = catalogObjectService.createCatalogObjectRevision(bucket.getName(),
                                                                          "object-name-1",
+                                                                         PROJECT_NAME,
                                                                          "commit message 2",
                                                                          "username",
                                                                          keyValues,
@@ -184,6 +185,7 @@ public class CatalogObjectServiceIntegrationTest {
 
         CatalogObjectMetadata catalogObjectMetadataNewKeyValue = catalogObjectService.createCatalogObjectRevision(bucket.getName(),
                                                                                                                   "object-name-3",
+                                                                                                                  PROJECT_NAME,
                                                                                                                   "commit message 2",
                                                                                                                   "username",
                                                                                                                   metadataList,
@@ -419,10 +421,13 @@ public class CatalogObjectServiceIntegrationTest {
     public void testUpdateProjectName() throws IOException, InterruptedException {
         String workflowName = "workflow";
         String bucketName = bucket.getName();
-        List<Metadata> metadataList1 = ImmutableList.of(new Metadata("project_name", "updated_project_1", null));
-        String updatedProjectName = "updated_project_2";
+        String updatedProjectName1 = "updated_project_1";
+        String updatedProjectName2 = "updated_project_2";
+        String updatedProjectName3 = "updated_project_3";
+        String updatedProjectName4 = "updated_project_4";
+        List<Metadata> metadataList = ImmutableList.of(new Metadata("project_name", updatedProjectName2, null));
 
-        //1. projectName initialization
+        //projectName initialization
         CatalogObjectMetadata catalogObjectMetadata = catalogObjectService.createCatalogObject(bucketName,
                                                                                                workflowName,
                                                                                                PROJECT_NAME,
@@ -438,34 +443,58 @@ public class CatalogObjectServiceIntegrationTest {
 
         Thread.sleep(1); // to be sure that a new revision time will be different from previous revision time
 
-        //2. First update
+        //1. First update
         catalogObjectMetadata = catalogObjectService.createCatalogObjectRevision(bucketName,
                                                                                  workflowName,
+                                                                                 updatedProjectName1,
                                                                                  "second commit message",
                                                                                  "username",
-                                                                                 metadataList1,
+                                                                                 Collections.emptyList(),
                                                                                  workflowAsByteArrayUpdated);
 
         assertThat(catalogObjectMetadata.getProjectName()).isEqualTo("updated_project_1");
 
-        //3. Second update
+        //2. Second update
+        catalogObjectMetadata = catalogObjectService.createCatalogObjectRevision(bucketName,
+                                                                                 workflowName,
+                                                                                 "",
+                                                                                 "third commit message",
+                                                                                 "username",
+                                                                                 metadataList,
+                                                                                 workflowAsByteArrayUpdated);
+
+        assertThat(catalogObjectMetadata.getProjectName()).isEqualTo("updated_project_2");
+
+        //3. Third update
         catalogObjectMetadata = catalogObjectService.updateObjectMetadata(bucketName,
                                                                           workflowName,
                                                                           Optional.empty(),
                                                                           Optional.empty(),
-                                                                          Optional.of(updatedProjectName));
+                                                                          Optional.of(updatedProjectName3));
 
-        assertThat(catalogObjectMetadata.getProjectName()).isEqualTo(updatedProjectName);
+        assertThat(catalogObjectMetadata.getProjectName()).isEqualTo("updated_project_3");
 
-        //4. Third update
+        //4. Fourth update
         catalogObjectMetadata = catalogObjectService.createCatalogObjectRevision(bucketName,
                                                                                  workflowName,
-                                                                                 "third commit message",
+                                                                                 "",
+                                                                                 "fourth commit message",
                                                                                  "username",
                                                                                  Collections.emptyList(),
                                                                                  IntegrationTestUtil.getWorkflowAsByteArray("workflow-with-project-name.xml"));
 
         assertThat(catalogObjectMetadata.getProjectName()).isEqualTo("1. Test Project");
+
+        // 5. Fifth update
+        catalogObjectMetadata = catalogObjectService.createCatalogObjectRevision(bucketName,
+                                                                                 workflowName,
+                                                                                 updatedProjectName4,
+                                                                                 "fifth commit message",
+                                                                                 "username",
+                                                                                 metadataList,
+                                                                                 workflowAsByteArrayUpdated);
+
+        assertThat(catalogObjectMetadata.getProjectName()).isEqualTo("updated_project_4");
 
     }
 
@@ -530,6 +559,7 @@ public class CatalogObjectServiceIntegrationTest {
         // Second commit of the bucket/A_Object to the catalog which has the dependency bucket/A_Object' depends on bucket/B_Object
         catalogObjectService.createCatalogObjectRevision(bucketName,
                                                          aObject,
+                                                         PROJECT_NAME,
                                                          "second commit message of A_Object",
                                                          "username",
                                                          IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model.xml"));
@@ -678,6 +708,7 @@ public class CatalogObjectServiceIntegrationTest {
         //Second commit of the bucket/A_Object workflow to the catalog which depends on bucket/D_Object and bucket/E_Object (different from the first commit bucket/A_Object' and bucket/B_Object)
         CatalogObjectMetadata catalogObjectMetadataOfSecondVersionOfAObject = catalogObjectService.createCatalogObjectRevision(bucketName,
                                                                                                                                aObject,
+                                                                                                                               PROJECT_NAME,
                                                                                                                                "second commit message of A_Object",
                                                                                                                                "username",
                                                                                                                                IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-second-commit.xml"));
@@ -740,6 +771,7 @@ public class CatalogObjectServiceIntegrationTest {
 
         CatalogObjectMetadata catalogObjectMetadataOfThirdVersionOfAObject = catalogObjectService.createCatalogObjectRevision(bucketName,
                                                                                                                               aObject,
+                                                                                                                              PROJECT_NAME,
                                                                                                                               "third commit message of A_Object",
                                                                                                                               "username",
                                                                                                                               IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-with-commit-time.xml"));
@@ -1027,7 +1059,7 @@ public class CatalogObjectServiceIntegrationTest {
     }
 
     @Test
-    public void testPageableCatalogObjectsByEmptyFilters() {
+    public void testPageableCatalogObjectsInBucketByEmptyFilters() {
         List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
                                                                                                                               "",
                                                                                                                               "",
@@ -1087,7 +1119,7 @@ public class CatalogObjectServiceIntegrationTest {
     }
 
     @Test
-    public void testPageableCatalogObjectsByKindAndContentTypeInBucket() {
+    public void testPageableCatalogObjectsInBucketByKindAndContentType() {
         List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
                                                                                                                               "object",
                                                                                                                               "",
@@ -1177,6 +1209,76 @@ public class CatalogObjectServiceIntegrationTest {
                                                                                                   1,
                                                                                                   2);
         assertThat(catalogObjects).hasSize(1);
+
+    }
+
+    @Test
+    public void testPageableCatalogObjectsInBucketGroupedByProjectName() {
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog4",
+                                                 "3. Project",
+                                                 "workflow-general",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog9",
+                                                 "1. Project",
+                                                 "workflow/pca",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog10",
+                                                 "2. Project",
+                                                 "workflow/standard",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog6",
+                                                 "2. Project",
+                                                 "workflow/standard",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog5",
+                                                 "1. Project",
+                                                 "workflow/standard",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
+                                                                                                                              "",
+                                                                                                                              "",
+                                                                                                                              "",
+                                                                                                                              0,
+                                                                                                                              Integer.MAX_VALUE);
+
+        assertThat(catalogObjects.get(0).getProjectName()).isEqualTo("1. Project");
+        assertThat(catalogObjects.get(4).getProjectName()).isEqualTo("3. Project");
 
     }
 

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceIntegrationTest.java
@@ -255,7 +255,7 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "first commit message of A_Object",
                                                  "username",
                                                  "application/xml",
-                                                 Collections.EMPTY_LIST,
+                                                 Collections.emptyList(),
                                                  IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-2.xml"),
                                                  null);
 
@@ -289,14 +289,14 @@ public class CatalogObjectServiceIntegrationTest {
         CatalogObjectDependencies catalogObjectDependencyListOfAObjectFirstCommit = catalogObjectService.getObjectDependencies(bucketName,
                                                                                                                                aObject,
                                                                                                                                firstCommitTimeDependsOn);
-        List<String> BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit = catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
+        List<String> bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit = catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
                                                                                                                                  .stream()
                                                                                                                                  .map(DependsOnCatalogObject::getBucketAndObjectName)
                                                                                                                                  .collect(Collectors.toList());
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).hasSize(3);
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains("data-connectors/FTP");
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains("finance/QuantLib");
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains("deep-learning-workflows/Custom_Sentiment_Analysis_In_Bing_News");
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).hasSize(3);
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains("data-connectors/FTP");
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains("finance/QuantLib");
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains("deep-learning-workflows/Custom_Sentiment_Analysis_In_Bing_News");
         assertThat(catalogObjectDependencyListOfAObjectFirstCommit.getCalledByList()).hasSize(0);
 
         // Second commit of the bucket/A_Object to the catalog which has the dependency bucket/A_Object' depends on bucket/B_Object
@@ -309,16 +309,16 @@ public class CatalogObjectServiceIntegrationTest {
         //if no revision number is specified, get ObjectDependencyList of the  last revision of the given object
         CatalogObjectDependencies catalogObjectDependencyListOfAObjectSecondCommit = catalogObjectService.getObjectDependencies(bucketName,
                                                                                                                                 aObject);
-        List<String> BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit = catalogObjectDependencyListOfAObjectSecondCommit.getDependsOnList()
+        List<String> bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit = catalogObjectDependencyListOfAObjectSecondCommit.getDependsOnList()
                                                                                                                                    .stream()
                                                                                                                                    .map(DependsOnCatalogObject::getBucketAndObjectName)
                                                                                                                                    .collect(Collectors.toList());
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).hasSize(4);
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).hasSize(4);
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
                                                                                                                                  bObject));
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains("data-connectors/FTP");
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains("finance/QuantLib");
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains("deep-learning-workflows/Custom_Sentiment_Analysis_In_Bing_News");
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains("data-connectors/FTP");
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains("finance/QuantLib");
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains("deep-learning-workflows/Custom_Sentiment_Analysis_In_Bing_News");
         assertThat(catalogObjectDependencyListOfAObjectSecondCommit.getCalledByList()).hasSize(0);
 
         //  Create a new catalog object 'bucket/B_Object' which is called by 'bucket/A_Object' and check that its calledBy list is not empty
@@ -328,20 +328,20 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "commit message",
                                                  "username",
                                                  "application/xml",
-                                                 Collections.EMPTY_LIST,
+                                                 Collections.emptyList(),
                                                  IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-2.xml"),
                                                  null);
 
         CatalogObjectDependencies catalogObjectDependencyListOfBObject = catalogObjectService.getObjectDependencies(bucketName,
                                                                                                                     bObject);
-        List<String> BucketAndObjectNameDependsOnListOfBObjectFromDB = catalogObjectDependencyListOfBObject.getDependsOnList()
+        List<String> bucketAndObjectNameDependsOnListOfBObjectFromDB = catalogObjectDependencyListOfBObject.getDependsOnList()
                                                                                                            .stream()
                                                                                                            .map(DependsOnCatalogObject::getBucketAndObjectName)
                                                                                                            .collect(Collectors.toList());
-        assertThat(BucketAndObjectNameDependsOnListOfBObjectFromDB).hasSize(3);
-        assertThat(BucketAndObjectNameDependsOnListOfBObjectFromDB).contains("data-connectors/FTP");
-        assertThat(BucketAndObjectNameDependsOnListOfBObjectFromDB).contains("finance/QuantLib");
-        assertThat(BucketAndObjectNameDependsOnListOfBObjectFromDB).contains("deep-learning-workflows/Custom_Sentiment_Analysis_In_Bing_News");
+        assertThat(bucketAndObjectNameDependsOnListOfBObjectFromDB).hasSize(3);
+        assertThat(bucketAndObjectNameDependsOnListOfBObjectFromDB).contains("data-connectors/FTP");
+        assertThat(bucketAndObjectNameDependsOnListOfBObjectFromDB).contains("finance/QuantLib");
+        assertThat(bucketAndObjectNameDependsOnListOfBObjectFromDB).contains("deep-learning-workflows/Custom_Sentiment_Analysis_In_Bing_News");
         assertThat(catalogObjectDependencyListOfBObject.getCalledByList()).hasSize(1);
         assertThat(catalogObjectDependencyListOfBObject.getCalledByList()).contains(separatorUtility.getConcatWithSeparator(bucketName,
                                                                                                                             aObject));
@@ -365,7 +365,7 @@ public class CatalogObjectServiceIntegrationTest {
                                                                                                                       "commit message for B_Object",
                                                                                                                       "username",
                                                                                                                       "application/xml",
-                                                                                                                      Collections.EMPTY_LIST,
+                                                                                                                      Collections.emptyList(),
                                                                                                                       IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-2.xml"),
                                                                                                                       null);
         catalogObjectMetadataOfFirstVersionOfBObject.getCommitDateTime()
@@ -379,7 +379,7 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "commit message for C_Object",
                                                  "username",
                                                  "application/xml",
-                                                 Collections.EMPTY_LIST,
+                                                 Collections.emptyList(),
                                                  IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-2.xml"),
                                                  null);
 
@@ -390,7 +390,7 @@ public class CatalogObjectServiceIntegrationTest {
                                                                                                                       "First commit message of A_Object",
                                                                                                                       "username",
                                                                                                                       "application/xml",
-                                                                                                                      Collections.EMPTY_LIST,
+                                                                                                                      Collections.emptyList(),
                                                                                                                       IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-first-commit.xml"),
                                                                                                                       null);
 
@@ -402,16 +402,16 @@ public class CatalogObjectServiceIntegrationTest {
         //Retrieve the CatalogObjectDependencies of the bucket/A_Object
         CatalogObjectDependencies catalogObjectDependencyListOfAObjectFirstCommit = catalogObjectService.getObjectDependencies(bucketName,
                                                                                                                                aObject);
-        List<String> BucketAndObjectNameDependsOnListOfAObjectFromDB = catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
+        List<String> bucketAndObjectNameDependsOnListOfAObjectFromDB = catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
                                                                                                                       .stream()
                                                                                                                       .map(DependsOnCatalogObject::getBucketAndObjectName)
                                                                                                                       .collect(Collectors.toList());
 
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDB).contains(separatorUtility.getConcatWithSeparator(bucketName,
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDB).contains(separatorUtility.getConcatWithSeparator(bucketName,
                                                                                                                      bObject));
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDB).contains(separatorUtility.getConcatWithSeparator(bucketName,
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDB).contains(separatorUtility.getConcatWithSeparator(bucketName,
                                                                                                                      cObject));
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDB).hasSize(2);
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDB).hasSize(2);
 
         // Check that the bucket/A_Object workflow has the info that the bucket/B_Object workflow is in the Catalog --> isInCatalog=True
         assertTrue(catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
@@ -461,14 +461,14 @@ public class CatalogObjectServiceIntegrationTest {
         CatalogObjectDependencies catalogObjectDependencyListOfAObjectSecondCommit = catalogObjectService.getObjectDependencies(bucketName,
                                                                                                                                 aObject,
                                                                                                                                 secondCommitTimeOfAObject);
-        List<String> BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit = catalogObjectDependencyListOfAObjectSecondCommit.getDependsOnList()
+        List<String> bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit = catalogObjectDependencyListOfAObjectSecondCommit.getDependsOnList()
                                                                                                                                    .stream()
                                                                                                                                    .map(DependsOnCatalogObject::getBucketAndObjectName)
                                                                                                                                    .collect(Collectors.toList());
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).hasSize(2);
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).hasSize(2);
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
                                                                                                                                  dObject));
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBSecondCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
                                                                                                                                  eObject));
         assertThat(catalogObjectDependencyListOfAObjectSecondCommit.getCalledByList()).hasSize(0);
 
@@ -491,16 +491,16 @@ public class CatalogObjectServiceIntegrationTest {
         catalogObjectDependencyListOfAObjectFirstCommit = catalogObjectService.getObjectDependencies(bucketName,
                                                                                                      aObject,
                                                                                                      firstCommitTimeOfAObject);
-        List<String> BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit = catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
+        List<String> bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit = catalogObjectDependencyListOfAObjectFirstCommit.getDependsOnList()
                                                                                                                                  .stream()
                                                                                                                                  .map(DependsOnCatalogObject::getBucketAndObjectName)
                                                                                                                                  .collect(Collectors.toList());
 
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
                                                                                                                                 bObject));
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).contains(separatorUtility.getConcatWithSeparator(bucketName,
                                                                                                                                 cObject));
-        assertThat(BucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).hasSize(2);
+        assertThat(bucketAndObjectNameDependsOnListOfAObjectFromDBFirstCommit).hasSize(2);
 
         /************ FOURTH TEST ****************/
 
@@ -566,7 +566,7 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "First commit message of A_Object",
                                                  "username",
                                                  "application/xml",
-                                                 Collections.EMPTY_LIST,
+                                                 Collections.emptyList(),
                                                  IntegrationTestUtil.getWorkflowAsByteArray("workflow_variables_with_catalog_object_model-with-commit-time.xml"),
                                                  null);
 
@@ -585,7 +585,7 @@ public class CatalogObjectServiceIntegrationTest {
                                                  "first commit message",
                                                  "username",
                                                  "application/xml",
-                                                 Collections.EMPTY_LIST,
+                                                 Collections.emptyList(),
                                                  IntegrationTestUtil.getWorkflowAsByteArray("workflow_with_script_url.xml"),
                                                  null);
 
@@ -620,23 +620,25 @@ public class CatalogObjectServiceIntegrationTest {
         CatalogObjectDependencies catalogObjectDependencyList = catalogObjectService.getObjectDependencies(bucketName,
                                                                                                            workflowName,
                                                                                                            firstCommitTimeDependsOn);
-        List<String> BucketAndObjectNameDependsOnListFromDB = catalogObjectDependencyList.getDependsOnList()
+        List<String> bucketAndObjectNameDependsOnListFromDB = catalogObjectDependencyList.getDependsOnList()
                                                                                          .stream()
                                                                                          .map(DependsOnCatalogObject::getBucketAndObjectName)
                                                                                          .collect(Collectors.toList());
-        assertThat(BucketAndObjectNameDependsOnListFromDB).hasSize(5);
-        assertThat(BucketAndObjectNameDependsOnListFromDB).contains("basic-examples/Native_Task");
-        assertThat(BucketAndObjectNameDependsOnListFromDB).contains("cloud-automation-scripts/Service_Start");
-        assertThat(BucketAndObjectNameDependsOnListFromDB).contains("cloud-automation-scripts/Pre_Trigger_Action");
-        assertThat(BucketAndObjectNameDependsOnListFromDB).contains("scripts/update_variables_from_system");
-        assertThat(BucketAndObjectNameDependsOnListFromDB).contains("scripts/update_variables_from_file");
+        assertThat(bucketAndObjectNameDependsOnListFromDB).hasSize(5);
+        assertThat(bucketAndObjectNameDependsOnListFromDB).contains("basic-examples/Native_Task");
+        assertThat(bucketAndObjectNameDependsOnListFromDB).contains("cloud-automation-scripts/Service_Start");
+        assertThat(bucketAndObjectNameDependsOnListFromDB).contains("cloud-automation-scripts/Pre_Trigger_Action");
+        assertThat(bucketAndObjectNameDependsOnListFromDB).contains("scripts/update_variables_from_system");
+        assertThat(bucketAndObjectNameDependsOnListFromDB).contains("scripts/update_variables_from_file");
         assertThat(catalogObjectDependencyList.getCalledByList()).hasSize(0);
 
     }
 
     @Test
     public void testListCatalogObjectsInBucket() {
-        List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjects(Arrays.asList(bucket.getName()));
+        List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjects(Arrays.asList(bucket.getName()),
+                                                                                             0,
+                                                                                             Integer.MAX_VALUE);
         assertThat(catalogObjects).hasSize(3);
     }
 
@@ -674,10 +676,10 @@ public class CatalogObjectServiceIntegrationTest {
 
     @Test(expected = KindOrContentTypeIsNotValidException.class)
     public void testUpdateObjectMetadataWrongKind() {
-        CatalogObjectMetadata catalogObjectMetadata = catalogObjectService.updateObjectMetadata(bucket.getName(),
-                                                                                                "object-name-1",
-                                                                                                Optional.of("updated-kind//a asdf"),
-                                                                                                Optional.of("updated-contentType"));
+        catalogObjectService.updateObjectMetadata(bucket.getName(),
+                                                  "object-name-1",
+                                                  Optional.of("updated-kind//a asdf"),
+                                                  Optional.of("updated-contentType"));
     }
 
     @Test(expected = KindOrContentTypeIsNotValidException.class)
@@ -698,7 +700,9 @@ public class CatalogObjectServiceIntegrationTest {
         List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
                                                                                                                               "object",
                                                                                                                               "",
-                                                                                                                              "");
+                                                                                                                              "",
+                                                                                                                              0,
+                                                                                                                              Integer.MAX_VALUE);
         assertThat(catalogObjects).hasSize(2);
 
         catalogObjectService.createCatalogObject(bucket.getName(),
@@ -714,14 +718,215 @@ public class CatalogObjectServiceIntegrationTest {
         catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
                                                                                                   "workflow-general",
                                                                                                   "",
-                                                                                                  "");
+                                                                                                  "",
+                                                                                                  0,
+                                                                                                  Integer.MAX_VALUE);
         assertThat(catalogObjects).hasSize(1);
 
         catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
                                                                                                   "WORKFLOW",
                                                                                                   "",
-                                                                                                  "");
+                                                                                                  "",
+                                                                                                  0,
+                                                                                                  Integer.MAX_VALUE);
         assertThat(catalogObjects).hasSize(2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPageableCatalogObjectsInBucketWrongPageNumber() {
+        catalogObjectService.listCatalogObjects(Arrays.asList(bucket.getName()), -1, Integer.MAX_VALUE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPageableCatalogObjectsInBucketWrongPageSize() {
+        catalogObjectService.listCatalogObjects(Arrays.asList(bucket.getName()), 0, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPageableCatalogObjectsByFiltersInBucketWrongParameters() {
+        catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
+                                                                                 "",
+                                                                                 "",
+                                                                                 "",
+                                                                                 -1,
+                                                                                 0);
+    }
+
+    @Test
+    public void testPageableCatalogObjectsInBucket() {
+        List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjects(Arrays.asList(bucket.getName()),
+                                                                                             0,
+                                                                                             2);
+        assertThat(catalogObjects).hasSize(2);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog4",
+                                                 "workflow-general",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog5",
+                                                 "workflow-general",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjects = catalogObjectService.listCatalogObjects(Arrays.asList(bucket.getName()), 2, 2);
+        assertThat(catalogObjects).hasSize(1);
+
+    }
+
+    @Test
+    public void testPageableCatalogObjectsByEmptyFilters() {
+        List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
+                                                                                                                              "",
+                                                                                                                              "",
+                                                                                                                              "",
+                                                                                                                              1,
+                                                                                                                              2);
+        assertThat(catalogObjects).hasSize(1);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog6",
+                                                 "workflow-general",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog4",
+                                                 "workflow-general",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog5",
+                                                 "workflow-general",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
+                                                                                                  "",
+                                                                                                  "",
+                                                                                                  "",
+                                                                                                  2,
+                                                                                                  3);
+        assertThat(catalogObjects).hasSize(0);
+        catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
+                                                                                                  "",
+                                                                                                  "",
+                                                                                                  "",
+                                                                                                  2,
+                                                                                                  2);
+        assertThat(catalogObjects).hasSize(2);
+
+    }
+
+    @Test
+    public void testPageableCatalogObjectsByKindAndContentTypeInBucket() {
+        List<CatalogObjectMetadata> catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
+                                                                                                                              "object",
+                                                                                                                              "",
+                                                                                                                              "",
+                                                                                                                              0,
+                                                                                                                              3);
+        assertThat(catalogObjects).hasSize(2);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog4",
+                                                 "workflow-general",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog5",
+                                                 "workflow/pca",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog6",
+                                                 "workflow/standard",
+                                                 "commit message",
+                                                 "username",
+                                                 "application/xml",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
+                                                                                                  "workflow",
+                                                                                                  "",
+                                                                                                  "",
+                                                                                                  1,
+                                                                                                  3);
+        assertThat(catalogObjects).hasSize(1);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog7",
+                                                 "Script",
+                                                 "commit message",
+                                                 "username",
+                                                 "text/x-python",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog8",
+                                                 "Script",
+                                                 "commit message",
+                                                 "username",
+                                                 "text/x-groovy",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjectService.createCatalogObject(bucket.getName(),
+                                                 "catalog9",
+                                                 "Script",
+                                                 "commit message",
+                                                 "username",
+                                                 "text/x-sh",
+                                                 keyValues,
+                                                 workflowAsByteArray,
+                                                 null);
+
+        catalogObjects = catalogObjectService.listCatalogObjectsByKindAndContentTypeAndObjectName(Arrays.asList(bucket.getName()),
+                                                                                                  "Script",
+                                                                                                  "text",
+                                                                                                  "",
+                                                                                                  1,
+                                                                                                  2);
+        assertThat(catalogObjects).hasSize(1);
+
     }
 
     @Test
@@ -945,7 +1150,7 @@ public class CatalogObjectServiceIntegrationTest {
         BucketMetadata secondBucket = bucketService.createBucket(secondBucketName,
                                                                  "CatalogObjectServiceIntegrationTest");
 
-        BucketMetadata emptyBucket = bucketService.createBucket("empty-bucket", "CatalogObjectServiceIntegrationTest");
+        bucketService.createBucket("empty-bucket", "CatalogObjectServiceIntegrationTest");
 
         //Adding the object to the new bucket
         catalogObjectService.createCatalogObject(secondBucket.getName(),

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/GraphqlServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/GraphqlServiceIntegrationTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 import java.io.IOException;
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +40,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ow2.proactive.catalog.IntegrationTestConfig;
 import org.ow2.proactive.catalog.dto.BucketMetadata;
-import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
 import org.ow2.proactive.catalog.dto.Metadata;
 import org.ow2.proactive.catalog.graphql.bean.CatalogObjectConnection;
 import org.ow2.proactive.catalog.graphql.fetcher.CatalogObjectFetcher;
@@ -87,6 +85,8 @@ public class GraphqlServiceIntegrationTest {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    private static final String EMPTY_STRING = "";
+
     @Before
     public void setup() throws IOException, NotAuthenticatedException, AccessDeniedException, InterruptedException {
         doReturn("link").when(catalogObjectMapper).generatLink(anyString(), anyString());
@@ -98,6 +98,7 @@ public class GraphqlServiceIntegrationTest {
         workflowAsByteArrayUpdated = IntegrationTestUtil.getWorkflowAsByteArray("workflow-updated.xml");
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog1",
+                                                 EMPTY_STRING,
                                                  "object",
                                                  "commit message",
                                                  "username",
@@ -116,6 +117,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog2",
+                                                 EMPTY_STRING,
                                                  "object",
                                                  "commit message",
                                                  "username",
@@ -128,6 +130,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog3",
+                                                 EMPTY_STRING,
                                                  "workflow",
                                                  "commit message",
                                                  "username",
@@ -138,6 +141,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog4",
+                                                 EMPTY_STRING,
                                                  "workflow",
                                                  "commit message",
                                                  "username",
@@ -147,6 +151,7 @@ public class GraphqlServiceIntegrationTest {
                                                  null);
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog5",
+                                                 EMPTY_STRING,
                                                  "nodesource",
                                                  "commit message",
                                                  "username",
@@ -157,6 +162,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog6",
+                                                 EMPTY_STRING,
                                                  "script",
                                                  "commit message",
                                                  "username",
@@ -167,6 +173,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog7",
+                                                 EMPTY_STRING,
                                                  "script",
                                                  "commit message",
                                                  "username",
@@ -551,6 +558,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket2.getName(),
                                                  "catalog1",
+                                                 EMPTY_STRING,
                                                  "object",
                                                  "commit message",
                                                  "username",

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/GraphqlServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/GraphqlServiceIntegrationTest.java
@@ -85,7 +85,7 @@ public class GraphqlServiceIntegrationTest {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private static final String EMPTY_STRING = "";
+    private static final String PROJECT_NAME = "projectName";
 
     @Before
     public void setup() throws IOException, NotAuthenticatedException, AccessDeniedException, InterruptedException {
@@ -98,7 +98,7 @@ public class GraphqlServiceIntegrationTest {
         workflowAsByteArrayUpdated = IntegrationTestUtil.getWorkflowAsByteArray("workflow-updated.xml");
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog1",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "object",
                                                  "commit message",
                                                  "username",
@@ -110,6 +110,7 @@ public class GraphqlServiceIntegrationTest {
         Thread.sleep(1); // to be sure that a new revision time will be different from previous revision time
         catalogObjectService.createCatalogObjectRevision(bucket.getName(),
                                                          "catalog1",
+                                                         PROJECT_NAME,
                                                          "commit message 2",
                                                          "username",
                                                          keyValues,
@@ -117,7 +118,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog2",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "object",
                                                  "commit message",
                                                  "username",
@@ -130,7 +131,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog3",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "workflow",
                                                  "commit message",
                                                  "username",
@@ -141,7 +142,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog4",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "workflow",
                                                  "commit message",
                                                  "username",
@@ -151,7 +152,7 @@ public class GraphqlServiceIntegrationTest {
                                                  null);
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog5",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "nodesource",
                                                  "commit message",
                                                  "username",
@@ -162,7 +163,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog6",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "script",
                                                  "commit message",
                                                  "username",
@@ -173,7 +174,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket.getName(),
                                                  "catalog7",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "script",
                                                  "commit message",
                                                  "username",
@@ -558,7 +559,7 @@ public class GraphqlServiceIntegrationTest {
 
         catalogObjectService.createCatalogObject(bucket2.getName(),
                                                  "catalog1",
-                                                 EMPTY_STRING,
+                                                 PROJECT_NAME,
                                                  "object",
                                                  "commit message",
                                                  "username",

--- a/src/integration-test/java/org/ow2/proactive/catalog/util/IntegrationTestUtil.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/util/IntegrationTestUtil.java
@@ -115,20 +115,21 @@ public class IntegrationTestUtil {
     }
 
     /**
-     *
-     * @param bucketId
-     * @param kind
+     *  @param bucketId
      * @param name
-     * @param commitMessage
+     * @param projectName
+     * @param kind
      * @param objectContentType
+     * @param commitMessage
      * @param file
      */
-    public static void postObjectToBucket(String bucketId, String kind, String name, String commitMessage,
-            String objectContentType, File file) {
+    public static void postObjectToBucket(String bucketId, String name, String projectName, String kind,
+            String objectContentType, String commitMessage, File file) {
         given().header("sessionID", "12345")
                .pathParam("bucketName", bucketId)
                .queryParam("kind", kind)
                .queryParam("name", name)
+               .queryParam("projectName", projectName)
                .queryParam("commitMessage", commitMessage)
                .queryParam("objectContentType", objectContentType)
                .multiPart(file)
@@ -161,10 +162,11 @@ public class IntegrationTestUtil {
      */
     public static void postDefaultWorkflowToBucket(String bucketId) {
         postObjectToBucket(bucketId,
-                           "workflow",
                            "my workflow",
-                           "first commit",
+                           "myobjectprojectname",
+                           "workflow",
                            "application/xml",
+                           "first commit",
                            IntegrationTestUtil.getWorkflowFile("workflow.xml"));
     }
 }

--- a/src/integration-test/resources/workflows/workflow-with-project-name.xml
+++ b/src/integration-test/resources/workflows/workflow-with-project-name.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.12" xsi:schemaLocation="urn:proactive:jobdescriptor:3.12 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.12/schedulerjob.xsd"  name="workflow-with-project-name" projectName="1. Test Project" priority="normal" onTaskError="continueJobExecution"  maxNumberOfExecution="2"  >
+  <description>
+    <![CDATA[ A workflow that executes Groovy in JVM. ]]>
+  </description>
+  <taskFlow>
+    <task name="Task1"
+    fork="true">
+      <description>
+        <![CDATA[ The simplest task, ran by a Groovy engine. ]]>
+      </description>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+println "Hello World from " + ("hostname".execute().text)
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+    <task name="Task2"
+    fork="true">
+      <depends>
+        <task ref="Task1"/>
+      </depends>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+println variables.get("PA_TASK_NAME")
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+  </taskFlow>
+</job>

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectMetadata.java
@@ -63,6 +63,9 @@ public class CatalogObjectMetadata extends ResourceSupport {
     @JsonProperty
     protected final String name;
 
+    @JsonProperty("project_name")
+    protected final String projectName;
+
     @JsonProperty
     protected final String extension;
 
@@ -82,11 +85,10 @@ public class CatalogObjectMetadata extends ResourceSupport {
     @JsonProperty("object_key_values")
     protected final List<Metadata> metadataList;
 
-    protected final String projectName;
-
     public CatalogObjectMetadata(CatalogObjectEntity catalogObject) {
         this(catalogObject.getBucket().getBucketName(),
              catalogObject.getId().getName(),
+             catalogObject.getRevisions().first().getProjectName(),
              catalogObject.getKind(),
              catalogObject.getContentType(),
              catalogObject.getRevisions().first().getCommitTime(),
@@ -99,6 +101,7 @@ public class CatalogObjectMetadata extends ResourceSupport {
     public CatalogObjectMetadata(CatalogObjectRevisionEntity catalogObject) {
         this(catalogObject.getCatalogObject().getBucket().getBucketName(),
              catalogObject.getCatalogObject().getId().getName(),
+             catalogObject.getProjectName(),
              catalogObject.getCatalogObject().getKind(),
              catalogObject.getCatalogObject().getContentType(),
              catalogObject.getCommitTime(),
@@ -108,8 +111,8 @@ public class CatalogObjectMetadata extends ResourceSupport {
              catalogObject.getCatalogObject().getExtension());
     }
 
-    public CatalogObjectMetadata(String bucketName, String name, String kind, String contentType, long commitTime,
-            String commitMessage, String username, List<Metadata> metadataList, String extension) {
+    public CatalogObjectMetadata(String bucketName, String name, String projectName, String kind, String contentType,
+            long commitTime, String commitMessage, String username, List<Metadata> metadataList, String extension) {
         this.bucketName = bucketName;
         this.name = name;
         this.kind = kind;
@@ -123,7 +126,11 @@ public class CatalogObjectMetadata extends ResourceSupport {
         } else {
             this.metadataList = metadataList;
         }
-        this.projectName = getProjectNameIfExistsOrEmptyString();
+        if (projectName != null && !projectName.isEmpty()) {
+            this.projectName = projectName;
+        } else {
+            this.projectName = getProjectNameIfExistsOrEmptyString();
+        }
         this.extension = extension;
 
     }

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogRawObject.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogRawObject.java
@@ -52,9 +52,19 @@ public class CatalogRawObject extends CatalogObjectMetadata {
         this.rawObject = catalogObject.getRawObject();
     }
 
-    public CatalogRawObject(String bucketName, String name, String kind, String contentType, long createdAt,
-            String commitMessage, String username, List<Metadata> metadataList, byte[] rawObject, String extension) {
-        super(bucketName, name, kind, contentType, createdAt, commitMessage, username, metadataList, extension);
+    public CatalogRawObject(String bucketName, String name, String projectName, String kind, String contentType,
+            long createdAt, String commitMessage, String username, List<Metadata> metadataList, byte[] rawObject,
+            String extension) {
+        super(bucketName,
+              name,
+              projectName,
+              kind,
+              contentType,
+              createdAt,
+              commitMessage,
+              username,
+              metadataList,
+              extension);
         this.rawObject = rawObject;
     }
 

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
@@ -32,7 +32,6 @@ import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
 import org.ow2.proactive.catalog.util.parser.WorkflowParser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
@@ -46,7 +46,7 @@ public interface CatalogObjectRevisionRepository extends JpaRepository<CatalogOb
         JpaSpecificationExecutor<CatalogObjectRevisionEntity> {
 
     @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.projectName = null OR cor.projectName = ''")
-    List<CatalogObjectRevisionEntity> findByProjectNameIsNullOrIsEmpty();
+    List<CatalogObjectRevisionEntity> findWithEmptyOrNullProjectName();
 
     @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1 AND cor.catalogObject.lastCommitTime = cor.commitTime ORDER BY cor.projectName")
     Page<CatalogObjectRevisionEntity> findDefaultCatalogObjectsInBucket(List<String> bucketNames, Pageable pageable);

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
@@ -30,6 +30,9 @@ import java.util.UUID;
 
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
 import org.ow2.proactive.catalog.util.parser.WorkflowParser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -44,13 +47,13 @@ public interface CatalogObjectRevisionRepository extends JpaRepository<CatalogOb
         JpaSpecificationExecutor<CatalogObjectRevisionEntity> {
 
     @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1 AND cor.catalogObject.lastCommitTime = cor.commitTime")
-    List<CatalogObjectRevisionEntity> findDefaultCatalogObjectsInBucket(List<String> bucketNames);
+    Page<CatalogObjectRevisionEntity> findDefaultCatalogObjectsInBucket(List<String> bucketNames, Pageable pageable);
 
     @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1" +
            " AND lower(cor.catalogObject.kind) LIKE lower(concat(?2, '%')) AND lower(cor.catalogObject.contentType) LIKE lower(concat(?3, '%'))" +
            " AND lower(cor.catalogObject.id.name) LIKE lower(concat('%', ?4, '%')) AND cor.catalogObject.lastCommitTime = cor.commitTime")
-    List<CatalogObjectRevisionEntity> findDefaultCatalogObjectsOfKindAndContentTypeAndObjectNameInBucket(
-            List<String> bucketNames, String kind, String contentType, String objectName);
+    Page<CatalogObjectRevisionEntity> findDefaultCatalogObjectsOfKindAndContentTypeAndObjectNameInBucket(
+            List<String> bucketNames, String kind, String contentType, String objectName, Pageable pageable);
 
     @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1 AND cor.catalogObject.id.name = ?2 AND cor.catalogObject.lastCommitTime = cor.commitTime")
     CatalogObjectRevisionEntity findDefaultCatalogObjectByNameInBucket(List<String> bucketNames, String name);

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
@@ -45,12 +45,15 @@ import org.springframework.data.repository.query.Param;
 public interface CatalogObjectRevisionRepository extends JpaRepository<CatalogObjectRevisionEntity, UUID>,
         JpaSpecificationExecutor<CatalogObjectRevisionEntity> {
 
-    @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1 AND cor.catalogObject.lastCommitTime = cor.commitTime")
+    @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.projectName = null OR cor.projectName = ''")
+    List<CatalogObjectRevisionEntity> findByProjectNameIsNullOrIsEmpty();
+
+    @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1 AND cor.catalogObject.lastCommitTime = cor.commitTime ORDER BY cor.projectName")
     Page<CatalogObjectRevisionEntity> findDefaultCatalogObjectsInBucket(List<String> bucketNames, Pageable pageable);
 
     @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1" +
            " AND lower(cor.catalogObject.kind) LIKE lower(concat(?2, '%')) AND lower(cor.catalogObject.contentType) LIKE lower(concat(?3, '%'))" +
-           " AND lower(cor.catalogObject.id.name) LIKE lower(concat('%', ?4, '%')) AND cor.catalogObject.lastCommitTime = cor.commitTime")
+           " AND lower(cor.catalogObject.id.name) LIKE lower(concat('%', ?4, '%')) AND cor.catalogObject.lastCommitTime = cor.commitTime ORDER BY cor.projectName")
     Page<CatalogObjectRevisionEntity> findDefaultCatalogObjectsOfKindAndContentTypeAndObjectNameInBucket(
             List<String> bucketNames, String kind, String contentType, String objectName, Pageable pageable);
 

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectRevisionEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectRevisionEntity.java
@@ -30,21 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Index;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinColumns;
-import javax.persistence.Lob;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import javax.persistence.*;
 
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Fetch;
@@ -55,6 +41,7 @@ import org.hibernate.annotations.Parameter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Setter;
 
 
 /**
@@ -76,6 +63,9 @@ public class CatalogObjectRevisionEntity implements Comparable, Serializable {
                                                                                                                                           @Parameter(name = "increment_size", value = "1") })
     @Column(name = "ID")
     protected Long id;
+
+    @Column(name = "PROJECT_NAME")
+    private String projectName;
 
     @Column(name = "COMMIT_MESSAGE")
     private String commitMessage;
@@ -143,6 +133,7 @@ public class CatalogObjectRevisionEntity implements Comparable, Serializable {
     @Override
     public String toString() {
         return "CatalogObjectRevisionRepository{" + "commitMessage='" + commitMessage + '\'' + ", username='" +
-               username + '\'' + ", commitTime=" + commitTime + ", metadataList=" + keyValueMetadataList + '}';
+               username + '\'' + ", commitTime='" + commitTime + '\'' + ", projectName='" + projectName + '\'' +
+               ", metadataList=" + keyValueMetadataList + '}';
     }
 }

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/KeyValueLabelMetadataEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/KeyValueLabelMetadataEntity.java
@@ -105,7 +105,7 @@ public class KeyValueLabelMetadataEntity implements Serializable {
 
     @Override
     public String toString() {
-        return "KeyValueLabelMetadataEntity{" + "key='" + key + '\'' + ", value='" + value + '\'' + ", type='" + label +
-               '\'' + '}';
+        return "KeyValueLabelMetadataEntity{" + "key='" + key + '\'' + ", value='" + value + '\'' + ", label='" +
+               label + '\'' + '}';
     }
 }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
@@ -106,7 +106,7 @@ public class BucketController {
     @ResponseStatus(HttpStatus.OK)
     public BucketMetadata updateBucketOwner(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the existing Bucket ") @PathVariable String bucketName,
+            @ApiParam(value = "The name of the existing Bucket ", required = true) @PathVariable String bucketName,
             @ApiParam(value = "The new name of the user that will own the Bucket") @RequestParam(value = "owner", required = true) String newOwnerName)
             throws NotAuthenticatedException, AccessDeniedException {
         if (sessionIdRequired) {

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -109,7 +109,7 @@ public class CatalogObjectController {
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName,
             @ApiParam(value = "Name of the object or empty when a ZIP archive is uploaded (All objects inside the archive are stored inside the catalog).") @RequestParam(required = false) Optional<String> name,
-            @ApiParam(value = "Project of the object") @RequestParam(value = "projectName", required = false, defaultValue = "") String projectName,
+            @ApiParam(value = "Project of the object") @RequestParam(value = "projectName", required = false, defaultValue = "") Optional<String> projectName,
             @ApiParam(value = "Kind of the new object", required = true) @RequestParam String kind,
             @ApiParam(value = "Commit message", required = true) @RequestParam String commitMessage,
             @ApiParam(value = "The Content-Type of CatalogRawObject - MIME type", required = true) @RequestParam String objectContentType,
@@ -121,7 +121,8 @@ public class CatalogObjectController {
         if (name.isPresent()) {
             CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObject(bucketName,
                                                                                            name.get(),
-                                                                                           projectName,
+                                                                                           projectName.isPresent() ? projectName.get()
+                                                                                                                   : "",
                                                                                            kind,
                                                                                            commitMessage,
                                                                                            restApiAccessResponse.getAuthenticatedUser()
@@ -136,7 +137,8 @@ public class CatalogObjectController {
             return new CatalogObjectMetadataList(catalogObject);
         } else {
             List<CatalogObjectMetadata> catalogObjects = catalogObjectService.createCatalogObjects(bucketName,
-                                                                                                   projectName,
+                                                                                                   projectName.isPresent() ? projectName.get()
+                                                                                                                           : "",
                                                                                                    kind,
                                                                                                    commitMessage,
                                                                                                    restApiAccessResponse.getAuthenticatedUser()

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -175,8 +175,8 @@ public class CatalogObjectController {
     @ResponseStatus(HttpStatus.OK)
     public List<CatalogObjectNameReference> listCatalogObjectNameReference(
             @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
-            @ApiParam(value = "Filter according to kind") @RequestHeader(value = "kind", required = false) Optional<String> kind,
-            @ApiParam(value = "Filter according to Content-Type") @RequestHeader(value = "contentType", required = false) Optional<String> contentType) {
+            @ApiParam(value = "Filter according to kind", required = false) @RequestParam(value = "kind", required = false) Optional<String> kind,
+            @ApiParam(value = "Filter according to Content-Type", required = false) @RequestParam(value = "contentType", required = false) Optional<String> contentType) {
         return catalogObjectService.getAccessibleCatalogObjectsNameReferenceByKindAndContentType(sessionIdRequired,
                                                                                                  sessionId,
                                                                                                  kind,

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -109,6 +109,7 @@ public class CatalogObjectController {
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName,
             @ApiParam(value = "Name of the object or empty when a ZIP archive is uploaded (All objects inside the archive are stored inside the catalog).") @RequestParam(required = false) Optional<String> name,
+            @ApiParam(value = "Project of the object") @RequestParam(value = "projectName", required = false, defaultValue = "") String projectName,
             @ApiParam(value = "Kind of the new object", required = true) @RequestParam String kind,
             @ApiParam(value = "Commit message", required = true) @RequestParam String commitMessage,
             @ApiParam(value = "The Content-Type of CatalogRawObject - MIME type", required = true) @RequestParam String objectContentType,
@@ -120,6 +121,7 @@ public class CatalogObjectController {
         if (name.isPresent()) {
             CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObject(bucketName,
                                                                                            name.get(),
+                                                                                           projectName,
                                                                                            kind,
                                                                                            commitMessage,
                                                                                            restApiAccessResponse.getAuthenticatedUser()
@@ -134,6 +136,7 @@ public class CatalogObjectController {
             return new CatalogObjectMetadataList(catalogObject);
         } else {
             List<CatalogObjectMetadata> catalogObjects = catalogObjectService.createCatalogObjects(bucketName,
+                                                                                                   projectName,
                                                                                                    kind,
                                                                                                    commitMessage,
                                                                                                    restApiAccessResponse.getAuthenticatedUser()
@@ -178,7 +181,7 @@ public class CatalogObjectController {
                                                                                                  contentType);
     }
 
-    @ApiOperation(value = "Update a catalog object metadata, like kind and Content-Type")
+    @ApiOperation(value = "Update a catalog object metadata, like kind, Content-Type and project name")
     @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket, object or revision not found"),
                             @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied"),
@@ -189,12 +192,13 @@ public class CatalogObjectController {
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName, @PathVariable String name,
             @ApiParam(value = "The new kind of an object", required = false) @RequestParam(value = "kind", required = false) Optional<String> kind,
-            @ApiParam(value = "The new Content-Type of an object - MIME type", required = false) @RequestParam(value = "contentType", required = false) Optional<String> contentType)
+            @ApiParam(value = "The new Content-Type of an object - MIME type", required = false) @RequestParam(value = "contentType", required = false) Optional<String> contentType,
+            @ApiParam(value = "The new project name of an object", required = false) @RequestParam(value = "projectName", required = false) Optional<String> projectName)
             throws UnsupportedEncodingException, NotAuthenticatedException, AccessDeniedException {
         restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionIdRequired,
                                                                                sessionId,
                                                                                bucketName);
-        return catalogObjectService.updateObjectMetadata(bucketName, name, kind, contentType);
+        return catalogObjectService.updateObjectMetadata(bucketName, name, kind, contentType, projectName);
     }
 
     @ApiOperation(value = "Gets a catalog object's metadata by IDs", notes = "Returns metadata associated to the latest revision of the catalog object.")

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -268,6 +268,8 @@ public class CatalogObjectController {
             @ApiParam(value = "Filter according to Content-Type.") @RequestParam(required = false) Optional<String> contentType,
             @ApiParam(value = "Filter according to Object Name.") @RequestParam(value = "objectName", required = false) Optional<String> objectNameFilter,
             @ApiParam(value = "Give a list of name separated by comma to get them in an archive", allowMultiple = true, type = "string") @RequestParam(value = "listObjectNamesForArchive", required = false) Optional<List<String>> names,
+            @ApiParam(value = "Page number", required = false) @RequestParam(defaultValue = "0", value = "pageNo") int pageNo,
+            @ApiParam(value = "Page size", required = false) @RequestParam(defaultValue = "50", value = "pageSize") int pageSize,
             HttpServletResponse response)
             throws UnsupportedEncodingException, NotAuthenticatedException, AccessDeniedException {
 
@@ -306,8 +308,9 @@ public class CatalogObjectController {
             List<CatalogObjectMetadata> metadataList = catalogObjectService.listCatalogObjects(Arrays.asList(bucketName),
                                                                                                kind,
                                                                                                contentType,
-                                                                                               objectNameFilter);
-
+                                                                                               objectNameFilter,
+                                                                                               pageNo,
+                                                                                               pageSize);
             for (CatalogObjectMetadata catalogObject : metadataList) {
                 catalogObject.add(LinkUtil.createLink(bucketName, catalogObject.getName()));
                 catalogObject.add(LinkUtil.createRelativeLink(bucketName, catalogObject.getName()));

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -97,6 +97,8 @@ public class CatalogObjectController {
 
     private static final String ZIP_CONTENT_TYPE = "application/zip";
 
+    private static final long MAXVALUE = Integer.MAX_VALUE;
+
     @Value("${pa.catalog.security.required.sessionid}")
     private boolean sessionIdRequired;
 
@@ -121,8 +123,7 @@ public class CatalogObjectController {
         if (name.isPresent()) {
             CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObject(bucketName,
                                                                                            name.get(),
-                                                                                           projectName.isPresent() ? projectName.get()
-                                                                                                                   : "",
+                                                                                           projectName.orElse(""),
                                                                                            kind,
                                                                                            commitMessage,
                                                                                            restApiAccessResponse.getAuthenticatedUser()
@@ -137,8 +138,7 @@ public class CatalogObjectController {
             return new CatalogObjectMetadataList(catalogObject);
         } else {
             List<CatalogObjectMetadata> catalogObjects = catalogObjectService.createCatalogObjects(bucketName,
-                                                                                                   projectName.isPresent() ? projectName.get()
-                                                                                                                           : "",
+                                                                                                   projectName.orElse(""),
                                                                                                    kind,
                                                                                                    commitMessage,
                                                                                                    restApiAccessResponse.getAuthenticatedUser()
@@ -275,7 +275,8 @@ public class CatalogObjectController {
             @ApiParam(value = "Filter according to Object Name.") @RequestParam(value = "objectName", required = false) Optional<String> objectNameFilter,
             @ApiParam(value = "Give a list of name separated by comma to get them in an archive", allowMultiple = true, type = "string") @RequestParam(value = "listObjectNamesForArchive", required = false) Optional<List<String>> names,
             @ApiParam(value = "Page number", required = false) @RequestParam(defaultValue = "0", value = "pageNo") int pageNo,
-            @ApiParam(value = "Page size", required = false) @RequestParam(defaultValue = "50", value = "pageSize") int pageSize,
+            @ApiParam(value = "Page size", required = false) @RequestParam(defaultValue = MAXVALUE +
+                                                                                          "", value = "pageSize") int pageSize,
             HttpServletResponse response)
             throws UnsupportedEncodingException, NotAuthenticatedException, AccessDeniedException {
 

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
@@ -103,8 +103,7 @@ public class CatalogObjectRevisionController {
                                                                                                                   bucketName);
         CatalogObjectMetadata catalogObjectRevision = catalogObjectService.createCatalogObjectRevision(bucketName,
                                                                                                        name,
-                                                                                                       projectName.isPresent() ? projectName.get()
-                                                                                                                               : "",
+                                                                                                       projectName.orElse(""),
                                                                                                        commitMessage,
                                                                                                        restApiAccessResponse.getAuthenticatedUser()
                                                                                                                             .getName(),

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
@@ -32,6 +32,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+import java.util.Optional;
 
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
 import org.ow2.proactive.catalog.dto.CatalogRawObject;
@@ -94,6 +95,7 @@ public class CatalogObjectRevisionController {
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName, @PathVariable String name,
             @ApiParam(value = "The commit message of the CatalogRawObject Revision", required = true) @RequestParam String commitMessage,
+            @ApiParam(value = "Project of the object") @RequestParam(value = "projectName", required = false, defaultValue = "") Optional<String> projectName,
             @RequestPart(value = "file") MultipartFile file)
             throws IOException, NotAuthenticatedException, AccessDeniedException {
         RestApiAccessResponse restApiAccessResponse = restApiAccessService.getUserDataFromSessionidAndCheckAccess(sessionIdRequired,
@@ -101,6 +103,8 @@ public class CatalogObjectRevisionController {
                                                                                                                   bucketName);
         CatalogObjectMetadata catalogObjectRevision = catalogObjectService.createCatalogObjectRevision(bucketName,
                                                                                                        name,
+                                                                                                       projectName.isPresent() ? projectName.get()
+                                                                                                                               : "",
                                                                                                        commitMessage,
                                                                                                        restApiAccessResponse.getAuthenticatedUser()
                                                                                                                             .getName(),

--- a/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
@@ -107,7 +107,9 @@ public class BucketService {
 
     //create a new revision for objects when the bucket owner is updated
     protected void createRevisionForObjects(String bucketName, String commitMessage) {
-        List<CatalogObjectRevisionEntity> objectsList = catalogObjectService.listCatalogObjectsEntities(Arrays.asList(bucketName));
+        List<CatalogObjectRevisionEntity> objectsList = catalogObjectService.listCatalogObjectsEntities(Arrays.asList(bucketName),
+                                                                                                        0,
+                                                                                                        Integer.MAX_VALUE);
 
         objectsList.forEach(obj -> catalogObjectService.createCatalogObjectRevision(obj, commitMessage));
     }

--- a/src/main/java/org/ow2/proactive/catalog/service/DatabaseBackwardCompatibilityManager.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/DatabaseBackwardCompatibilityManager.java
@@ -1,0 +1,49 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.log4j.Log4j2;
+
+
+@Log4j2
+@Component
+public class DatabaseBackwardCompatibilityManager {
+
+    @Autowired
+    ProjectNameStartupAdder projectNameStartupAdder;
+
+    @PostConstruct
+    public void initSetProjectNameInCatalogObjectRevisionEntity() {
+
+        projectNameStartupAdder.synchronizeProjectName();
+
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/KeyValueLabelMetadataHelper.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/KeyValueLabelMetadataHelper.java
@@ -101,7 +101,7 @@ public class KeyValueLabelMetadataHelper {
 
     }
 
-    public List<Metadata> convertFromEntity(List<KeyValueLabelMetadataEntity> source) {
+    public static List<Metadata> convertFromEntity(List<KeyValueLabelMetadataEntity> source) {
         return source.stream().map(Metadata::new).collect(Collectors.toList());
     }
 

--- a/src/main/java/org/ow2/proactive/catalog/service/ProjectNameStartupAdder.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/ProjectNameStartupAdder.java
@@ -31,6 +31,7 @@ import org.ow2.proactive.catalog.repository.CatalogObjectRevisionRepository;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -45,21 +46,17 @@ public class ProjectNameStartupAdder {
     @Autowired
     CatalogObjectService catalogObjectService;
 
+    @Transactional
     public void synchronizeProjectName() {
         log.info("Checking catalog object revision entities ... ");
         List<CatalogObjectRevisionEntity> catalogObjectRevisionEntityList = catalogObjectRevisionRepository.findByProjectNameIsNullOrIsEmpty();
         if (!catalogObjectRevisionEntityList.isEmpty()) {
             log.info("Resynchronization of project name ...");
-            for (CatalogObjectRevisionEntity entity : catalogObjectRevisionEntityList) {
-                String projectName = catalogObjectService.getProjectNameIfExistsOrEmptyString(KeyValueLabelMetadataHelper.convertFromEntity(entity.getKeyValueMetadataList()));
-                CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectService.findCatalogObjectByNameAndBucketAndCheck(entity.getCatalogObject()
-                                                                                                                                              .getBucket()
-                                                                                                                                              .getBucketName(),
-                                                                                                                                        entity.getCatalogObject()
-                                                                                                                                              .getId()
-                                                                                                                                              .getName());
-                catalogObjectRevisionEntity.setProjectName(projectName);
-                catalogObjectRevisionRepository.save(catalogObjectRevisionEntity);
+            for (CatalogObjectRevisionEntity objectRevisionEntity : catalogObjectRevisionEntityList) {
+                String projectName = catalogObjectService.getProjectNameIfExistsOrEmptyString(KeyValueLabelMetadataHelper.convertFromEntity(objectRevisionEntity.getKeyValueMetadataList()));
+
+                objectRevisionEntity.setProjectName(projectName);
+                catalogObjectRevisionRepository.save(objectRevisionEntity);
 
             }
             log.info("Resynchronization of project name ended successfully.");

--- a/src/main/java/org/ow2/proactive/catalog/service/ProjectNameStartupAdder.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/ProjectNameStartupAdder.java
@@ -49,7 +49,7 @@ public class ProjectNameStartupAdder {
     @Transactional
     public void synchronizeProjectName() {
         log.info("Checking catalog object revision entities ... ");
-        List<CatalogObjectRevisionEntity> catalogObjectRevisionEntityList = catalogObjectRevisionRepository.findByProjectNameIsNullOrIsEmpty();
+        List<CatalogObjectRevisionEntity> catalogObjectRevisionEntityList = catalogObjectRevisionRepository.findWithEmptyOrNullProjectName();
         if (!catalogObjectRevisionEntityList.isEmpty()) {
             log.info("Resynchronization of project name ...");
             for (CatalogObjectRevisionEntity objectRevisionEntity : catalogObjectRevisionEntityList) {

--- a/src/main/java/org/ow2/proactive/catalog/service/ProjectNameStartupAdder.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/ProjectNameStartupAdder.java
@@ -1,0 +1,69 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service;
+
+import java.util.List;
+
+import org.ow2.proactive.catalog.repository.CatalogObjectRevisionRepository;
+import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.log4j.Log4j2;
+
+
+@Log4j2
+@Component
+public class ProjectNameStartupAdder {
+
+    @Autowired
+    private CatalogObjectRevisionRepository catalogObjectRevisionRepository;
+
+    @Autowired
+    CatalogObjectService catalogObjectService;
+
+    public void synchronizeProjectName() {
+        log.info("Checking catalog object revision entities ... ");
+        List<CatalogObjectRevisionEntity> catalogObjectRevisionEntityList = catalogObjectRevisionRepository.findByProjectNameIsNullOrIsEmpty();
+        if (!catalogObjectRevisionEntityList.isEmpty()) {
+            log.info("Resynchronization of project name ...");
+            for (CatalogObjectRevisionEntity entity : catalogObjectRevisionEntityList) {
+                String projectName = catalogObjectService.getProjectNameIfExistsOrEmptyString(KeyValueLabelMetadataHelper.convertFromEntity(entity.getKeyValueMetadataList()));
+                CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectService.findCatalogObjectByNameAndBucketAndCheck(entity.getCatalogObject()
+                                                                                                                                              .getBucket()
+                                                                                                                                              .getBucketName(),
+                                                                                                                                        entity.getCatalogObject()
+                                                                                                                                              .getId()
+                                                                                                                                              .getName());
+                catalogObjectRevisionEntity.setProjectName(projectName);
+                catalogObjectRevisionRepository.save(catalogObjectRevisionEntity);
+
+            }
+            log.info("Resynchronization of project name ended successfully.");
+        }
+
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/util/CatalogObjectJSONParser.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/CatalogObjectJSONParser.java
@@ -53,6 +53,8 @@ public final class CatalogObjectJSONParser {
 
         private String name;
 
+        private String projectName;
+
         private String kind;
 
         private String commitMessage;
@@ -69,6 +71,14 @@ public final class CatalogObjectJSONParser {
 
         public void setName(String name) {
             this.name = name;
+        }
+
+        public String getProjectName() {
+            return projectName;
+        }
+
+        public void setProjectName(String projectName) {
+            this.projectName = projectName;
         }
 
         public String getKind() {

--- a/src/test/java/org/ow2/proactive/catalog/dto/CatalogObjectMetadataTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/dto/CatalogObjectMetadataTest.java
@@ -68,6 +68,7 @@ public class CatalogObjectMetadataTest {
 
         CatalogObjectMetadata catalogObjectMetadata = new CatalogObjectMetadata(bucketName,
                                                                                 name,
+                                                                                "",
                                                                                 "kind",
                                                                                 "contentType",
                                                                                 123546587L,

--- a/src/test/java/org/ow2/proactive/catalog/report/CatalogObjectReportPDFGeneratorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/report/CatalogObjectReportPDFGeneratorTest.java
@@ -131,6 +131,7 @@ public class CatalogObjectReportPDFGeneratorTest {
 
         catalogObjectMetadataSet = Sets.newSet(new CatalogObjectMetadata("bucketName",
                                                                          "objectName",
+                                                                         "projectName",
                                                                          kind.get(),
                                                                          "projectName",
                                                                          1L,

--- a/src/test/java/org/ow2/proactive/catalog/report/TableCatalogObjectsDependenciesBuilderTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/report/TableCatalogObjectsDependenciesBuilderTest.java
@@ -115,6 +115,7 @@ public class TableCatalogObjectsDependenciesBuilderTest {
 
         final CatalogObjectMetadata catalogObjectMetadata = new CatalogObjectMetadata(bucketName,
                                                                                       objectName,
+                                                                                      "projectName",
                                                                                       kind,
                                                                                       "projectName",
                                                                                       1L,

--- a/src/test/java/org/ow2/proactive/catalog/report/TableDataBuilderTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/report/TableDataBuilderTest.java
@@ -78,6 +78,7 @@ public class TableDataBuilderTest {
         final String objectName = "objectName";
         final String bucketName = "bucketName";
         final String kind = "kind";
+        final String contentType = "contentType";
         final String projectName = "projectName";
         final String description = "objectDescription";
         final String variable1Key = "var1Key";
@@ -114,8 +115,9 @@ public class TableDataBuilderTest {
         Set<CatalogObjectMetadata> catalogObjectMetadataSet = new HashSet<>();
         catalogObjectMetadataSet.add(new CatalogObjectMetadata(bucketName,
                                                                objectName,
-                                                               kind,
                                                                projectName,
+                                                               kind,
+                                                               contentType,
                                                                1400343L,
                                                                "commit message",
                                                                "username",

--- a/src/test/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectEntityTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectEntityTest.java
@@ -102,6 +102,7 @@ public class CatalogObjectEntityTest {
 
     private CatalogObjectRevisionEntity newCatalogObjectRevision(LocalDateTime time) {
         return new CatalogObjectRevisionEntity(null,
+                                               "projectName",
                                                "commit message",
                                                "username",
                                                time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
@@ -104,6 +104,8 @@ public class CatalogObjectControllerTest {
                                      Optional.empty(),
                                      Optional.empty(),
                                      Optional.of(nameList),
+                                     0,
+                                     Integer.MAX_VALUE,
                                      response);
         verify(catalogObjectService, times(1)).getCatalogObjectsAsZipArchive("bucket-name", nameList);
         verify(response, times(1)).setStatus(HttpServletResponse.SC_OK);
@@ -132,6 +134,8 @@ public class CatalogObjectControllerTest {
                                      Optional.empty(),
                                      Optional.empty(),
                                      Optional.of(nameList),
+                                     0,
+                                     Integer.MAX_VALUE,
                                      response);
         verify(catalogObjectService, times(1)).getCatalogObjectsAsZipArchive("bucket-name", nameList);
         verify(response, never()).setStatus(HttpServletResponse.SC_OK);
@@ -150,11 +154,15 @@ public class CatalogObjectControllerTest {
                                      Optional.empty(),
                                      Optional.empty(),
                                      Optional.empty(),
+                                     0,
+                                     Integer.MAX_VALUE,
                                      response);
         verify(catalogObjectService, times(1)).listCatalogObjects(anyList(),
                                                                   any(Optional.class),
                                                                   any(Optional.class),
-                                                                  any(Optional.class));
+                                                                  any(Optional.class),
+                                                                  any(Integer.class),
+                                                                  any(Integer.class));
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
@@ -88,6 +88,8 @@ public class CatalogObjectControllerTest {
     @Mock
     private RestApiAccessService restApiAccessService;
 
+    private static final String PROJECT_NAME = "projectName";
+
     @Test
     public void testGetCatalogObjectsAsArchive() throws IOException, NotAuthenticatedException, AccessDeniedException {
         HttpServletResponse response = mock(HttpServletResponse.class);
@@ -169,6 +171,7 @@ public class CatalogObjectControllerTest {
     public void testGetRaw() throws Exception {
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           "name",
+                                                          PROJECT_NAME,
                                                           "object",
                                                           "application/xml",
                                                           1400343L,
@@ -194,6 +197,7 @@ public class CatalogObjectControllerTest {
     public void testDelete() throws Exception {
         CatalogObjectMetadata mock = new CatalogObjectMetadata("bucket-name",
                                                                "name",
+                                                               PROJECT_NAME,
                                                                "object",
                                                                "application/xml",
                                                                1400343L,

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerTest.java
@@ -78,6 +78,7 @@ public class CatalogObjectRevisionControllerTest {
     public void testGetRevisionRaw() throws Exception {
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           "name",
+                                                          "projectName",
                                                           "object",
                                                           "application/xml",
                                                           1400343L,

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketServiceTest.java
@@ -135,13 +135,17 @@ public class BucketServiceTest {
 
         when(bucketRepository.findOneByBucketName(anyString())).thenReturn(mockedBucket);
         when(bucketRepository.save(mockedBucket)).thenReturn(mockedBucketWithOwner);
-        when(catalogObjectService.listCatalogObjectsEntities((Arrays.asList(bucketName)))).thenReturn(objectsList);
+        when(catalogObjectService.listCatalogObjectsEntities((Arrays.asList(bucketName)),
+                                                             0,
+                                                             Integer.MAX_VALUE)).thenReturn(objectsList);
 
         BucketMetadata bucketMetadata = bucketService.updateOwnerByBucketName(bucketName, DEFAULT_BUCKET_NAME);
         verify(mockedBucket, times(1)).setOwner(DEFAULT_BUCKET_NAME);
         verify(bucketRepository, times(1)).findOneByBucketName(bucketName);
         verify(bucketRepository, times(1)).save(mockedBucket);
-        verify(catalogObjectService, times(1)).listCatalogObjectsEntities(Arrays.asList(bucketName));
+        verify(catalogObjectService, times(1)).listCatalogObjectsEntities(Arrays.asList(bucketName),
+                                                                          0,
+                                                                          Integer.MAX_VALUE);
         verify(catalogObjectService, times(1)).createCatalogObjectRevision(catalogObjectRevisionEntity,
                                                                            BucketService.COMMIT_MESSAGE_UPDATE_BUCKET);
         assertEquals(mockedBucketWithOwner.getBucketName(), bucketMetadata.getName());

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectCallGraphServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectCallGraphServiceTest.java
@@ -244,6 +244,7 @@ public class CatalogObjectCallGraphServiceTest {
                                                                       WorkflowParser.ATTRIBUTE_DEPENDS_ON_LABEL));
         CatalogObjectMetadata catalogObjectMetadata = new CatalogObjectMetadata(bucketName,
                                                                                 name,
+                                                                                "projectName",
                                                                                 "kind",
                                                                                 "contentType",
                                                                                 System.currentTimeMillis(),

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectCallGraphServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectCallGraphServiceTest.java
@@ -221,7 +221,9 @@ public class CatalogObjectCallGraphServiceTest {
         Optional<String> contentType = Optional.empty();
 
         List<CatalogObjectMetadata> objectsMetadata = Lists.newArrayList();
-        when(catalogObjectService.listCatalogObjects(anyList())).thenReturn(objectsMetadata);
+        when(catalogObjectService.listCatalogObjects(anyList(),
+                                                     any(Integer.class),
+                                                     any(Integer.class))).thenReturn(objectsMetadata);
 
         when(catalogObjectCallGraphPDFGenerator.generatePdfImage(objectsMetadata,
                                                                  kind,

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectReportServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectReportServiceTest.java
@@ -78,7 +78,9 @@ public class CatalogObjectReportServiceTest {
         Optional<String> contentType = Optional.empty();
 
         List<CatalogObjectMetadata> objectsMetadata = Lists.newArrayList();
-        when(catalogObjectService.listCatalogObjects(anyList())).thenReturn(objectsMetadata);
+        when(catalogObjectService.listCatalogObjects(anyList(),
+                                                     any(Integer.class),
+                                                     any(Integer.class))).thenReturn(objectsMetadata);
 
         TreeSet<CatalogObjectMetadata> orderedObjectsPerBucket = sortObjectsPerBucket(objectsMetadata);
 

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectReportServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectReportServiceTest.java
@@ -253,6 +253,7 @@ public class CatalogObjectReportServiceTest {
         List<Metadata> metadataList = Lists.newArrayList(new Metadata("project_name", "project " + name, "label"));
         CatalogObjectMetadata catalogObjectMetadata = new CatalogObjectMetadata(bucketName,
                                                                                 name,
+                                                                                "projectName",
                                                                                 "kind",
                                                                                 "contentType",
                                                                                 System.currentTimeMillis(),

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
@@ -264,7 +264,7 @@ public class CatalogObjectServiceTest {
     @Test(expected = BucketNotFoundException.class)
     public void testGetCatalogObjectWithInvalidBucket() {
         when(bucketRepository.findOneByBucketName(anyString())).thenReturn(null);
-        catalogObjectService.listCatalogObjects(Arrays.asList("wrong-bucket"));
+        catalogObjectService.listCatalogObjects(Arrays.asList("wrong-bucket"), 0, Integer.MAX_VALUE);
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
@@ -83,6 +83,8 @@ public class CatalogObjectServiceTest {
 
     public static final long REVISION_COMMIT_TIME = 1551960076669L;
 
+    public static final String PROJECT_NAME = "projectName";
+
     @InjectMocks
     private CatalogObjectService catalogObjectService;
 
@@ -117,6 +119,7 @@ public class CatalogObjectServiceTest {
         when(bucketRepository.findOneByBucketName(anyString())).thenReturn(null);
         catalogObjectService.createCatalogObject("bucket",
                                                  NAME,
+                                                 PROJECT_NAME,
                                                  OBJECT,
                                                  COMMIT_MESSAGE,
                                                  USERNAME,
@@ -174,6 +177,7 @@ public class CatalogObjectServiceTest {
 
         CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObject("bucket",
                                                                                        NAME,
+                                                                                       PROJECT_NAME,
                                                                                        OBJECT,
                                                                                        COMMIT_MESSAGE,
                                                                                        USERNAME,
@@ -188,6 +192,7 @@ public class CatalogObjectServiceTest {
         assertThat(catalogObject.getContentType()).isEqualTo(APPLICATION_XML);
         assertThat(catalogObject.getKind()).isEqualTo(OBJECT);
         assertThat(catalogObject.getName()).isEqualTo(NAME);
+        assertThat(catalogObject.getProjectName()).isEqualTo(PROJECT_NAME);
         assertThat(catalogObject.getMetadataList()).isNotEmpty();
         assertThat(catalogObject.getMetadataList()).hasSize(1);
     }
@@ -204,6 +209,7 @@ public class CatalogObjectServiceTest {
         catalogObjectService.updateObjectMetadata(bucketEntity.getBucketName(),
                                                   NAME,
                                                   Optional.empty(),
+                                                  Optional.empty(),
                                                   Optional.empty());
     }
 
@@ -214,6 +220,7 @@ public class CatalogObjectServiceTest {
         when(bucketRepository.findOneByBucketName(anyString())).thenReturn(bucketEntity);
         CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObject("bucket",
                                                                                        "bad/name",
+                                                                                       PROJECT_NAME,
                                                                                        OBJECT,
                                                                                        COMMIT_MESSAGE,
                                                                                        USERNAME,
@@ -230,7 +237,8 @@ public class CatalogObjectServiceTest {
         catalogObjectService.updateObjectMetadata("wrong-bucket",
                                                   NAME,
                                                   Optional.of("some-kind"),
-                                                  Optional.of("some-contentType"));
+                                                  Optional.of("some-contentType"),
+                                                  Optional.of("some-projectName"));
     }
 
     @Test(expected = CatalogObjectNotFoundException.class)
@@ -242,7 +250,8 @@ public class CatalogObjectServiceTest {
         catalogObjectService.updateObjectMetadata(bucketEntity.getBucketName(),
                                                   "wrong-name",
                                                   Optional.of("some-kind"),
-                                                  Optional.of("some-contentType"));
+                                                  Optional.of("some-contentType"),
+                                                  Optional.of("some-projectName"));
     }
 
     @Test(expected = KindOrContentTypeIsNotValidException.class)
@@ -258,7 +267,8 @@ public class CatalogObjectServiceTest {
         CatalogObjectMetadata catalogObject = catalogObjectService.updateObjectMetadata(bucketEntity.getBucketName(),
                                                                                         NAME,
                                                                                         Optional.of("some-kind//fgf' g"),
-                                                                                        Optional.of("updated-contentType"));
+                                                                                        Optional.of("updated-contentType"),
+                                                                                        Optional.of("some-projectName"));
     }
 
     @Test(expected = BucketNotFoundException.class)
@@ -280,7 +290,8 @@ public class CatalogObjectServiceTest {
         CatalogObjectMetadata catalogObject = catalogObjectService.updateObjectMetadata(bucketEntity.getBucketName(),
                                                                                         NAME,
                                                                                         Optional.of("updated-kind"),
-                                                                                        Optional.of("updated-contentType"));
+                                                                                        Optional.of("updated-contentType"),
+                                                                                        Optional.of("updated-projectName"));
 
         assertThat(catalogObject).isNotNull();
         assertThat(catalogObject.getCommitMessage()).isEqualTo(COMMIT_MESSAGE);
@@ -288,6 +299,7 @@ public class CatalogObjectServiceTest {
 
         assertThat(catalogObject.getContentType()).isEqualTo("updated-contentType");
         assertThat(catalogObject.getKind()).isEqualTo("updated-kind");
+        assertThat(catalogObject.getProjectName()).isEqualTo("updated-projectName");
         assertThat(catalogObject.getName()).isEqualTo(NAME);
         assertThat(catalogObject.getMetadataList()).isNotEmpty();
         assertThat(catalogObject.getMetadataList()).hasSize(1);
@@ -295,19 +307,20 @@ public class CatalogObjectServiceTest {
     }
 
     @Test
-    public void testUpdateObjectMetadataOnlyKindOrOnlyContentType() {
+    public void testUpdateObjectMetadataOnlyKindOrOnlyContentTypeOrOnlyProjectName() {
         long now = System.currentTimeMillis();
-        BucketEntity bucketEntity = new BucketEntity("bucket", "toto");
+        BucketEntity bucketEntity = new BucketEntity("cket", "toto");
         CatalogObjectRevisionEntity catalogObjectEntity = newCatalogObjectRevisionEntity(bucketEntity, now);
         when(bucketRepository.findOneByBucketName(anyString())).thenReturn(bucketEntity);
         when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(anyList(),
                                                                                     anyString())).thenReturn(catalogObjectEntity);
         when(kindAndContentTypeValidator.isValid(anyString())).thenReturn(true);
 
-        // only kind should be updated without changing contentType
+        // only kind should be updated without changing contentType and ProjectName
         CatalogObjectMetadata catalogObjectUpdatedKind = catalogObjectService.updateObjectMetadata(bucketEntity.getBucketName(),
                                                                                                    NAME,
                                                                                                    Optional.of("updated-kind"),
+                                                                                                   Optional.empty(),
                                                                                                    Optional.empty());
 
         assertThat(catalogObjectUpdatedKind).isNotNull();
@@ -321,11 +334,12 @@ public class CatalogObjectServiceTest {
         assertThat(catalogObjectUpdatedKind.getMetadataList()).hasSize(1);
         assertThat(catalogObjectUpdatedKind.getCommitTimeRaw()).isEqualTo(String.valueOf(now));
 
-        // only contentType should be updated without changing kind
+        // only contentType should be updated without changing kind and projectName
         CatalogObjectMetadata catalogObjectUpdatedContentType = catalogObjectService.updateObjectMetadata(bucketEntity.getBucketName(),
                                                                                                           NAME,
                                                                                                           Optional.empty(),
-                                                                                                          Optional.of("updated-contentType"));
+                                                                                                          Optional.of("updated-contentType"),
+                                                                                                          Optional.empty());
 
         assertThat(catalogObjectUpdatedContentType).isNotNull();
         assertThat(catalogObjectUpdatedContentType.getCommitMessage()).isEqualTo(COMMIT_MESSAGE);
@@ -337,6 +351,25 @@ public class CatalogObjectServiceTest {
         assertThat(catalogObjectUpdatedContentType.getMetadataList()).isNotEmpty();
         assertThat(catalogObjectUpdatedContentType.getMetadataList()).hasSize(1);
         assertThat(catalogObjectUpdatedContentType.getCommitTimeRaw()).isEqualTo(String.valueOf(now));
+
+        // only projectName should be updated without changing kind and contentType
+        CatalogObjectMetadata catalogObjectUpdatedProjectName = catalogObjectService.updateObjectMetadata(bucketEntity.getBucketName(),
+                                                                                                          NAME,
+                                                                                                          Optional.empty(),
+                                                                                                          Optional.empty(),
+                                                                                                          Optional.of("updated-projectName"));
+
+        assertThat(catalogObjectUpdatedProjectName).isNotNull();
+        assertThat(catalogObjectUpdatedProjectName.getCommitMessage()).isEqualTo(COMMIT_MESSAGE);
+        assertThat(catalogObjectUpdatedProjectName.getUsername()).isEqualTo(USERNAME);
+
+        assertThat(catalogObjectUpdatedProjectName.getContentType()).isEqualTo("updated-contentType");
+        assertThat(catalogObjectUpdatedProjectName.getKind()).isEqualTo("updated-kind");
+        assertThat(catalogObjectUpdatedProjectName.getProjectName()).isEqualTo("updated-projectName");
+        assertThat(catalogObjectUpdatedProjectName.getName()).isEqualTo(NAME);
+        assertThat(catalogObjectUpdatedProjectName.getMetadataList()).isNotEmpty();
+        assertThat(catalogObjectUpdatedProjectName.getMetadataList()).hasSize(1);
+        assertThat(catalogObjectUpdatedProjectName.getCommitTimeRaw()).isEqualTo(String.valueOf(now));
     }
 
     @Test(expected = CatalogObjectNotFoundException.class)
@@ -448,6 +481,7 @@ public class CatalogObjectServiceTest {
                                                                                                        "value",
                                                                                                        null));
         CatalogObjectRevisionEntity catalogObjectRevisionEntity = CatalogObjectRevisionEntity.builder()
+                                                                                             .projectName(PROJECT_NAME)
                                                                                              .commitMessage(COMMIT_MESSAGE)
                                                                                              .commitTime(now)
                                                                                              .catalogObject(catalogObjectEntity)
@@ -466,10 +500,11 @@ public class CatalogObjectServiceTest {
                                                                      .contentType("application/xml")
                                                                      .lastCommitTime(now)
                                                                      .build();
-        List<KeyValueLabelMetadataEntity> keyvalues = ImmutableList.of(new KeyValueLabelMetadataEntity("key",
-                                                                                                       "value",
+        List<KeyValueLabelMetadataEntity> keyvalues = ImmutableList.of(new KeyValueLabelMetadataEntity("key1",
+                                                                                                       "value2",
                                                                                                        null));
         CatalogObjectRevisionEntity catalogObjectRevisionEntity = CatalogObjectRevisionEntity.builder()
+                                                                                             .projectName(PROJECT_NAME)
                                                                                              .commitMessage(COMMIT_MESSAGE)
                                                                                              .commitTime(now)
                                                                                              .username(USERNAME)
@@ -515,6 +550,7 @@ public class CatalogObjectServiceTest {
                                                                                                keyvalues,
                                                                                                null);
         assertThat(catalogObject).isNotNull();
+        assertThat(catalogObject.getProjectName()).isEqualTo(PROJECT_NAME);
         assertThat(catalogObject.getCommitMessage()).isEqualTo(COMMIT_MESSAGE);
         assertThat(catalogObject.getUsername()).isEqualTo(USERNAME);
         assertThat(catalogObject.getContentType()).isEqualTo(APPLICATION_XML);
@@ -549,6 +585,7 @@ public class CatalogObjectServiceTest {
                                                                                                                                   now);
 
         assertThat(catalogObjectRevisionEntity).isNotNull();
+        assertThat(catalogObjectRevisionEntity.getProjectName()).isEqualTo(PROJECT_NAME);
         assertThat(catalogObjectRevisionEntity.getCommitMessage()).isEqualTo(COMMIT_MESSAGE);
         assertThat(catalogObjectRevisionEntity.getCatalogObject().getContentType()).isEqualTo(APPLICATION_XML);
         assertThat(catalogObjectRevisionEntity.getCatalogObject().getKind()).isEqualTo(OBJECT);

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectServiceTest.java
@@ -528,7 +528,7 @@ public class CatalogObjectServiceTest {
         List<KeyValueLabelMetadataEntity> keyvalues = ImmutableList.of(new KeyValueLabelMetadataEntity("key",
                                                                                                        "value",
                                                                                                        null));
-        catalogObjectService.createCatalogObjectRevision("bucket", NAME, COMMIT_MESSAGE, USERNAME, null);
+        catalogObjectService.createCatalogObjectRevision("bucket", NAME, PROJECT_NAME, COMMIT_MESSAGE, USERNAME, null);
     }
 
     @Test
@@ -545,6 +545,7 @@ public class CatalogObjectServiceTest {
                                                                                         any())).thenReturn(Collections.emptyList());
         CatalogObjectMetadata catalogObject = catalogObjectService.createCatalogObjectRevision("bucket",
                                                                                                NAME,
+                                                                                               PROJECT_NAME,
                                                                                                COMMIT_MESSAGE,
                                                                                                USERNAME,
                                                                                                keyvalues,

--- a/src/test/java/org/ow2/proactive/catalog/util/CatalogObjectJSONParserTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/CatalogObjectJSONParserTest.java
@@ -49,6 +49,7 @@ public class CatalogObjectJSONParserTest {
 
         assertThat(data.getKind()).isEqualTo("workflow");
         assertThat(data.getName()).isEqualTo("workflow name");
+        assertThat(data.getProjectName()).isEqualTo("workflow project name");
         assertThat(data.getCommitMessage()).isEqualTo("First commit");
         assertThat(data.getUsername()).isEqualTo("username");
         assertThat(data.getObjectFileName()).isEqualTo("myFileName.xml");

--- a/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
@@ -45,6 +45,8 @@ public class RawObjectResponseCreatorTest {
 
     private RawObjectResponseCreator rawObjectResponseCreator = new RawObjectResponseCreator();
 
+    private static final String EMPTY_STRING = "";
+
     @Test
     public void testCreateRawObjectResponseGeneralKindRightContentType() {
         String objectName = "object name";
@@ -52,6 +54,7 @@ public class RawObjectResponseCreatorTest {
         String contentDispositionFileName = "attachment; filename=\"" + objectName + "." + fileExtension + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
+                                                          EMPTY_STRING,
                                                           "object",
                                                           "application/xml",
                                                           1400343L,
@@ -78,6 +81,7 @@ public class RawObjectResponseCreatorTest {
         String contentDispositionFileName = "attachment; filename=\"" + objectName + "." + fileExtension + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
+                                                          EMPTY_STRING,
                                                           "workflow",
                                                           "application/xml",
                                                           1400343L,
@@ -104,6 +108,7 @@ public class RawObjectResponseCreatorTest {
                                             RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
+                                                          EMPTY_STRING,
                                                           "workflow/specific-workflow-kind",
                                                           "application/xml",
                                                           1400343L,
@@ -128,6 +133,7 @@ public class RawObjectResponseCreatorTest {
                                             RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
+                                                          EMPTY_STRING,
                                                           "workflow/specific-workflow-kind",
                                                           "application/xml",
                                                           1400343L,
@@ -152,6 +158,7 @@ public class RawObjectResponseCreatorTest {
                                             RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
+                                                          EMPTY_STRING,
                                                           "workflow/specific-workflow-kind",
                                                           "application/xml",
                                                           1400343L,
@@ -173,6 +180,7 @@ public class RawObjectResponseCreatorTest {
     public void testCreateRawObjectResponseWrongContentType() {
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           "name",
+                                                          EMPTY_STRING,
                                                           "object",
                                                           "testContentType",
                                                           1400343L,

--- a/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/RawObjectResponseCreatorTest.java
@@ -45,7 +45,7 @@ public class RawObjectResponseCreatorTest {
 
     private RawObjectResponseCreator rawObjectResponseCreator = new RawObjectResponseCreator();
 
-    private static final String EMPTY_STRING = "";
+    private static final String PROJECT_NAME = "projectName";
 
     @Test
     public void testCreateRawObjectResponseGeneralKindRightContentType() {
@@ -54,7 +54,7 @@ public class RawObjectResponseCreatorTest {
         String contentDispositionFileName = "attachment; filename=\"" + objectName + "." + fileExtension + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
-                                                          EMPTY_STRING,
+                                                          PROJECT_NAME,
                                                           "object",
                                                           "application/xml",
                                                           1400343L,
@@ -81,7 +81,7 @@ public class RawObjectResponseCreatorTest {
         String contentDispositionFileName = "attachment; filename=\"" + objectName + "." + fileExtension + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
-                                                          EMPTY_STRING,
+                                                          PROJECT_NAME,
                                                           "workflow",
                                                           "application/xml",
                                                           1400343L,
@@ -108,7 +108,7 @@ public class RawObjectResponseCreatorTest {
                                             RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
-                                                          EMPTY_STRING,
+                                                          PROJECT_NAME,
                                                           "workflow/specific-workflow-kind",
                                                           "application/xml",
                                                           1400343L,
@@ -133,7 +133,7 @@ public class RawObjectResponseCreatorTest {
                                             RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
-                                                          EMPTY_STRING,
+                                                          PROJECT_NAME,
                                                           "workflow/specific-workflow-kind",
                                                           "application/xml",
                                                           1400343L,
@@ -158,7 +158,7 @@ public class RawObjectResponseCreatorTest {
                                             RawObjectResponseCreator.WORKFLOW_EXTENSION + "\"";
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           objectName,
-                                                          EMPTY_STRING,
+                                                          PROJECT_NAME,
                                                           "workflow/specific-workflow-kind",
                                                           "application/xml",
                                                           1400343L,
@@ -180,7 +180,7 @@ public class RawObjectResponseCreatorTest {
     public void testCreateRawObjectResponseWrongContentType() {
         CatalogRawObject rawObject = new CatalogRawObject("bucket-name",
                                                           "name",
-                                                          EMPTY_STRING,
+                                                          PROJECT_NAME,
                                                           "object",
                                                           "testContentType",
                                                           1400343L,

--- a/src/test/java/org/ow2/proactive/catalog/util/ReportGeneratorHelperTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/util/ReportGeneratorHelperTest.java
@@ -135,6 +135,7 @@ public class ReportGeneratorHelperTest {
 
         CatalogObjectMetadata catalogObjectMetadata1 = new CatalogObjectMetadata(bucketName,
                                                                                  objectName1,
+                                                                                 "projectName",
                                                                                  "object",
                                                                                  "application/xml",
                                                                                  1400343L,
@@ -145,6 +146,7 @@ public class ReportGeneratorHelperTest {
 
         CatalogObjectMetadata catalogObjectMetadata2 = new CatalogObjectMetadata("bucket-name",
                                                                                  objectName2,
+                                                                                 "projectName",
                                                                                  "object",
                                                                                  "application/xml",
                                                                                  1400343L,

--- a/src/test/resources/objects/workflow.json
+++ b/src/test/resources/objects/workflow.json
@@ -1,6 +1,7 @@
 {
 	"kind": "workflow",
 	"name": "workflow name",
+	"projectName": "workflow project name",
 	"commitMessage": "First commit",
 	"username": "username",
 	"objectFileName": "myFileName.xml",


### PR DESCRIPTION
In this PR, we: 
1. Add projectName field in CatlogObjectRevisionEntity and update related endpoints (create, update, etc) to support this field.
2. Implement the pagination mechanism when we list catalog objects
3. Add some unit and integration tests
4. Implement database backward compatibility with respect to projectName field