### PR TITLE
Add Grant support for Catalog buckets and objects

### DIFF
--- a/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
@@ -36,16 +36,12 @@ import org.ow2.proactive.catalog.graphql.bean.argument.CatalogObjectWhereArgs;
 import org.ow2.proactive.catalog.graphql.fetcher.CatalogObjectFetcher;
 import org.ow2.proactive.catalog.graphql.handler.FilterHandler;
 import org.ow2.proactive.catalog.graphql.handler.catalogobject.*;
+import org.ow2.proactive.catalog.mocks.BucketGrantServiceMock;
+import org.ow2.proactive.catalog.mocks.CatalogObjectGrantServiceMock;
+import org.ow2.proactive.catalog.mocks.GrantAccessTypeHelperServiceMock;
 import org.ow2.proactive.catalog.mocks.RestApiAccessServiceMock;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
-import org.ow2.proactive.catalog.service.BucketService;
-import org.ow2.proactive.catalog.service.CatalogObjectService;
-import org.ow2.proactive.catalog.service.GraphqlService;
-import org.ow2.proactive.catalog.service.KeyValueLabelMetadataHelper;
-import org.ow2.proactive.catalog.service.OwnerGroupStringHelper;
-import org.ow2.proactive.catalog.service.RestApiAccessService;
-import org.ow2.proactive.catalog.service.WorkflowInfoAdder;
-import org.ow2.proactive.catalog.service.WorkflowXmlManipulator;
+import org.ow2.proactive.catalog.service.*;
 import org.ow2.proactive.catalog.util.ArchiveManagerHelper;
 import org.ow2.proactive.catalog.util.RawObjectResponseCreator;
 import org.ow2.proactive.catalog.util.RevisionCommitMessageBuilder;
@@ -277,5 +273,23 @@ public class IntegrationTestConfig {
     @Primary
     public RestApiAccessService restApiAccessService() {
         return new RestApiAccessServiceMock();
+    }
+
+    @Bean
+    @Primary
+    public BucketGrantService bucketGrantService() {
+        return new BucketGrantServiceMock();
+    }
+
+    @Bean
+    @Primary
+    public CatalogObjectGrantService catalogObjectGrantService() {
+        return new CatalogObjectGrantServiceMock();
+    }
+
+    @Bean
+    @Primary
+    public GrantAccessTypeHelperService grantAccessTypeHelperService() {
+        return new GrantAccessTypeHelperServiceMock();
     }
 }

--- a/src/integration-test/java/org/ow2/proactive/catalog/mocks/BucketGrantServiceMock.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/mocks/BucketGrantServiceMock.java
@@ -31,12 +31,8 @@ import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
 
 public class BucketGrantServiceMock extends BucketGrantService {
 
-    public BucketGrantServiceMock(){
-        super();
-    }
-
-    public boolean isTheUserGrantSufficientForTheCurrentTask(AuthenticatedUser user,
-                                                             String bucketName, String requiredAccessType) {
+    public boolean isTheUserGrantSufficientForTheCurrentTask(AuthenticatedUser user, String bucketName,
+            String requiredAccessType) {
         return true;
     }
 

--- a/src/integration-test/java/org/ow2/proactive/catalog/mocks/BucketGrantServiceMock.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/mocks/BucketGrantServiceMock.java
@@ -1,0 +1,46 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.mocks;
+
+import org.ow2.proactive.catalog.service.BucketGrantService;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+
+
+public class BucketGrantServiceMock extends BucketGrantService {
+
+    public BucketGrantServiceMock(){
+        super();
+    }
+
+    public boolean isTheUserGrantSufficientForTheCurrentTask(AuthenticatedUser user,
+                                                             String bucketName, String requiredAccessType) {
+        return true;
+    }
+
+    public void deleteAllBucketGrants(long bucketId) {
+
+    }
+}

--- a/src/integration-test/java/org/ow2/proactive/catalog/mocks/CatalogObjectGrantServiceMock.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/mocks/CatalogObjectGrantServiceMock.java
@@ -35,10 +35,6 @@ import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
 
 public class CatalogObjectGrantServiceMock extends CatalogObjectGrantService {
 
-    public CatalogObjectGrantServiceMock(){
-        super();
-    }
-
     public boolean checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(
             AuthenticatedUser user, String bucketName, String catalogObjectName) {
         return true;

--- a/src/integration-test/java/org/ow2/proactive/catalog/mocks/CatalogObjectGrantServiceMock.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/mocks/CatalogObjectGrantServiceMock.java
@@ -1,0 +1,56 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.mocks;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetaData;
+import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+
+
+public class CatalogObjectGrantServiceMock extends CatalogObjectGrantService {
+
+    public CatalogObjectGrantServiceMock(){
+        super();
+    }
+
+    public boolean checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(
+            AuthenticatedUser user, String bucketName, String catalogObjectName) {
+        return true;
+    }
+
+    public boolean checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(AuthenticatedUser user,
+            String bucketName) {
+        return true;
+    }
+
+    public List<CatalogObjectGrantMetaData> findAllCatalogObjectGrantsAssignedToABucket(String bucketName) {
+        return new LinkedList<>();
+    }
+
+}

--- a/src/integration-test/java/org/ow2/proactive/catalog/mocks/CatalogObjectGrantServiceMock.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/mocks/CatalogObjectGrantServiceMock.java
@@ -28,7 +28,7 @@ package org.ow2.proactive.catalog.mocks;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetaData;
+import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetadata;
 import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
 import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
 
@@ -49,7 +49,7 @@ public class CatalogObjectGrantServiceMock extends CatalogObjectGrantService {
         return true;
     }
 
-    public List<CatalogObjectGrantMetaData> findAllCatalogObjectGrantsAssignedToABucket(String bucketName) {
+    public List<CatalogObjectGrantMetadata> findAllCatalogObjectGrantsAssignedToABucket(String bucketName) {
         return new LinkedList<>();
     }
 

--- a/src/integration-test/java/org/ow2/proactive/catalog/mocks/GrantAccessTypeHelperServiceMock.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/mocks/GrantAccessTypeHelperServiceMock.java
@@ -1,0 +1,40 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.mocks;
+
+import org.ow2.proactive.catalog.service.GrantAccessTypeHelperService;
+
+
+public class GrantAccessTypeHelperServiceMock extends GrantAccessTypeHelperService {
+
+    public GrantAccessTypeHelperServiceMock(){
+        super();
+    }
+
+    public boolean compareGrantAccessType(String currentAccessType, String requiredAccessType) {
+        return true;
+    }
+}

--- a/src/integration-test/java/org/ow2/proactive/catalog/mocks/GrantAccessTypeHelperServiceMock.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/mocks/GrantAccessTypeHelperServiceMock.java
@@ -30,10 +30,6 @@ import org.ow2.proactive.catalog.service.GrantAccessTypeHelperService;
 
 public class GrantAccessTypeHelperServiceMock extends GrantAccessTypeHelperService {
 
-    public GrantAccessTypeHelperServiceMock(){
-        super();
-    }
-
     public boolean compareGrantAccessType(String currentAccessType, String requiredAccessType) {
         return true;
     }

--- a/src/integration-test/java/org/ow2/proactive/catalog/mocks/RestApiAccessServiceMock.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/mocks/RestApiAccessServiceMock.java
@@ -69,4 +69,16 @@ public class RestApiAccessServiceMock extends RestApiAccessService {
         return true;
     }
 
+    public boolean isSessionActive(String sessionId) {
+        return true;
+    }
+
+    public boolean isBucketAccessibleByUser(boolean sessionIdRequired, String sessionId, String bucketName) {
+        return true;
+    }
+
+    public AuthenticatedUser getUserFromSessionId(String sessionId) {
+        return AuthenticatedUser.builder().name("username").groups(Lists.newArrayList()).build();
+    }
+
 }

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/AbstractRestAssuredTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/AbstractRestAssuredTest.java
@@ -57,6 +57,16 @@ public abstract class AbstractRestAssuredTest {
 
     protected static final String ERROR_MESSAGE = "errorMessage";
 
+    protected static final String BUCKETS_GRANTS_RESOURCE = "/buckets/grant";
+
+    protected static final String BUCKET_GRANT_RESOURCE = "/buckets/grant/{bucketName}";
+
+    protected static final String BUCKETS_GRANTS_RESOURCE_USER = "/buckets/grant/{username}";
+
+    protected static final String CATALOG_OBJECT_GRANTS_RESOURCE = "/buckets/{bucketName}/grant/resources/{catalogObjectName}/grant";
+
+    protected static final String CATALOG_OBJECTS_GRANTS_RESOURCE = "/buckets/{bucketName}/grant";
+
     @Value("${local.server.port}")
     private int serverPort;
 

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/BucketGrantControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/BucketGrantControllerIntegrationTest.java
@@ -1,0 +1,326 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.rest.controller;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ow2.proactive.catalog.Application;
+import org.ow2.proactive.catalog.util.IntegrationTestUtil;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.jayway.restassured.response.Response;
+
+
+/**
+ * @author ActiveEon Team
+ */
+@ActiveProfiles("test")
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { Application.class })
+@WebIntegrationTest(randomPort = true)
+public class BucketGrantControllerIntegrationTest extends AbstractRestAssuredTest {
+
+    private final String bucketName = "test";
+
+    private final String bucketOwner = "BucketControllerIntegrationTest";
+
+    private final String currentUser = "admin";
+
+    private final String grantee = "user";
+
+    private final String accessType = "read";
+
+    @After
+    public void cleanup() {
+        IntegrationTestUtil.cleanup();
+    }
+
+    @Test
+    public void testCreateBucketGrantForSpecificUserShouldReturnSavedGrant() {
+        Response createBucketResponse = given().header("sessionID", "12345")
+                                               .parameters("name", bucketName, "owner", bucketOwner)
+                                               .when()
+                                               .post(BUCKETS_RESOURCE);
+
+        createBucketResponse.then()
+                            .assertThat()
+                            .statusCode(HttpStatus.SC_CREATED)
+                            .body("name", is(bucketName))
+                            .body("owner", is(bucketOwner));
+
+        Response createBucketGrantResponse = given().header("sessionID", "12345")
+                                                    .parameters("bucketName",
+                                                                bucketName,
+                                                                "currentUser",
+                                                                currentUser,
+                                                                "accessType",
+                                                                accessType,
+                                                                "username",
+                                                                grantee)
+                                                    .when()
+                                                    .post(BUCKETS_GRANTS_RESOURCE);
+
+        createBucketGrantResponse.then()
+                                 .assertThat()
+                                 .statusCode(HttpStatus.SC_CREATED)
+                                 .body("accessType", is(accessType))
+                                 .body("granteeType", is("user"))
+                                 .body("grantee", is(grantee));
+    }
+
+    @Test
+    public void testCreateBucketGrantForSpecificUserGroupShouldReturnSavedGrant() {
+        Response createBucketResponse = given().header("sessionID", "12345")
+                                               .parameters("name", bucketName, "owner", bucketOwner)
+                                               .when()
+                                               .post(BUCKETS_RESOURCE);
+
+        createBucketResponse.then()
+                            .assertThat()
+                            .statusCode(HttpStatus.SC_CREATED)
+                            .body("name", is(bucketName))
+                            .body("owner", is(bucketOwner));
+
+        Response createBucketGrantResponse = given().header("sessionID", "12345")
+                                                    .parameters("bucketName",
+                                                                bucketName,
+                                                                "currentUser",
+                                                                currentUser,
+                                                                "accessType",
+                                                                accessType,
+                                                                "userGroup",
+                                                                grantee)
+                                                    .when()
+                                                    .post(BUCKETS_GRANTS_RESOURCE);
+
+        createBucketGrantResponse.then()
+                                 .assertThat()
+                                 .statusCode(HttpStatus.SC_CREATED)
+                                 .body("accessType", is(accessType))
+                                 .body("granteeType", is("group"))
+                                 .body("grantee", is(grantee));
+    }
+
+    @Test
+    public void testUpdateBucketGrantForSpecificUser() {
+        Response createBucketResponse = given().header("sessionID", "12345")
+                                               .parameters("name", bucketName, "owner", bucketOwner)
+                                               .when()
+                                               .post(BUCKETS_RESOURCE);
+
+        createBucketResponse.then()
+                            .assertThat()
+                            .statusCode(HttpStatus.SC_CREATED)
+                            .body("name", is(bucketName))
+                            .body("owner", is(bucketOwner));
+
+        Response createBucketGrantResponse = given().header("sessionID", "12345")
+                                                    .parameters("bucketName",
+                                                                bucketName,
+                                                                "currentUser",
+                                                                currentUser,
+                                                                "accessType",
+                                                                accessType,
+                                                                "username",
+                                                                grantee)
+                                                    .when()
+                                                    .post(BUCKETS_GRANTS_RESOURCE);
+
+        createBucketGrantResponse.then()
+                                 .assertThat()
+                                 .statusCode(HttpStatus.SC_CREATED)
+                                 .body("accessType", is(accessType))
+                                 .body("grantee", is(grantee));
+
+        Response updateBucketGrantResponse = given().header("sessionID", "12345")
+                                                    .header("accessType", "admin")
+                                                    .header("username", grantee)
+                                                    .pathParam("bucketName", bucketName)
+                                                    .parameters("currentUser", currentUser)
+                                                    .when()
+                                                    .put(BUCKET_GRANT_RESOURCE);
+
+        updateBucketGrantResponse.then()
+                                 .assertThat()
+                                 .statusCode(HttpStatus.SC_OK)
+                                 .body("granteeType", is("user"))
+                                 .body("accessType", not(accessType))
+                                 .body("grantee", is(grantee));
+    }
+
+    @Test
+    public void testUpdateBucketGrantForSpecificUserGroup() {
+        Response createBucketResponse = given().header("sessionID", "12345")
+                                               .parameters("name", bucketName, "owner", bucketOwner)
+                                               .when()
+                                               .post(BUCKETS_RESOURCE);
+
+        createBucketResponse.then()
+                            .assertThat()
+                            .statusCode(HttpStatus.SC_CREATED)
+                            .body("name", is(bucketName))
+                            .body("owner", is(bucketOwner));
+
+        Response createBucketGrantResponse = given().header("sessionID", "12345")
+                                                    .parameters("bucketName",
+                                                                bucketName,
+                                                                "currentUser",
+                                                                currentUser,
+                                                                "accessType",
+                                                                accessType,
+                                                                "userGroup",
+                                                                grantee)
+                                                    .when()
+                                                    .post(BUCKETS_GRANTS_RESOURCE);
+
+        createBucketGrantResponse.then()
+                                 .assertThat()
+                                 .statusCode(HttpStatus.SC_CREATED)
+                                 .body("accessType", is(accessType))
+                                 .body("grantee", is(grantee));
+
+        Response updateBucketGrantResponse = given().header("sessionID", "12345")
+                                                    .header("accessType", "admin")
+                                                    .header("userGroup", grantee)
+                                                    .pathParam("bucketName", bucketName)
+                                                    .parameters("currentUser", currentUser)
+                                                    .when()
+                                                    .put(BUCKET_GRANT_RESOURCE);
+
+        updateBucketGrantResponse.then()
+                                 .assertThat()
+                                 .statusCode(HttpStatus.SC_OK)
+                                 .body("accessType", not(accessType))
+                                 .body("grantee", is(grantee));
+    }
+
+    @Test
+    public void testGetAllBucketGrantsCreatedBySpecificUser() {
+        Response createBucketResponse = given().header("sessionID", "12345")
+                                               .parameters("name", bucketName, "owner", bucketOwner)
+                                               .when()
+                                               .post(BUCKETS_RESOURCE);
+
+        createBucketResponse.then()
+                            .assertThat()
+                            .statusCode(HttpStatus.SC_CREATED)
+                            .body("name", is(bucketName))
+                            .body("owner", is(bucketOwner));
+
+        Response createBucketGrantResponse = given().header("sessionID", "12345")
+                                                    .parameters("bucketName",
+                                                                bucketName,
+                                                                "currentUser",
+                                                                currentUser,
+                                                                "accessType",
+                                                                accessType,
+                                                                "username",
+                                                                grantee)
+                                                    .when()
+                                                    .post(BUCKETS_GRANTS_RESOURCE);
+
+        createBucketGrantResponse.then()
+                                 .assertThat()
+                                 .statusCode(HttpStatus.SC_CREATED)
+                                 .body("accessType", is(accessType))
+                                 .body("grantee", is(grantee));
+
+        List<HashMap<String, String>> data = given().header("sessionID", "12345")
+                                                    .pathParam("username", currentUser)
+                                                    .get(BUCKETS_GRANTS_RESOURCE_USER)
+                                                    .then()
+                                                    .statusCode(HttpStatus.SC_OK)
+                                                    .extract()
+                                                    .path("");
+
+        assertEquals(1, data.size());
+        assertEquals(grantee, data.get(0).get("grantee"));
+        assertEquals(accessType, data.get(0).get("accessType"));
+        assertEquals(currentUser, data.get(0).get("creator"));
+    }
+
+    @Test
+    public void testGetAllBucketGrantsAssignedToSpecificUserAndHisGroup() {
+        Response createBucketResponse = given().header("sessionID", "12345")
+                                               .parameters("name", bucketName, "owner", bucketOwner)
+                                               .when()
+                                               .post(BUCKETS_RESOURCE);
+
+        createBucketResponse.then()
+                            .assertThat()
+                            .statusCode(HttpStatus.SC_CREATED)
+                            .body("name", is(bucketName))
+                            .body("owner", is(bucketOwner));
+
+        Response createBucketGrantResponse = given().header("sessionID", "12345")
+                                                    .parameters("bucketName",
+                                                                bucketName,
+                                                                "currentUser",
+                                                                currentUser,
+                                                                "accessType",
+                                                                accessType,
+                                                                "username",
+                                                                grantee)
+                                                    .when()
+                                                    .post(BUCKETS_GRANTS_RESOURCE);
+
+        createBucketGrantResponse.then()
+                                 .assertThat()
+                                 .statusCode(HttpStatus.SC_CREATED)
+                                 .body("accessType", is(accessType))
+                                 .body("grantee", is(grantee))
+                                 .body("granteeType", is("user"));
+
+        List<String> userGroups = new LinkedList<>();
+        userGroups.add("group");
+        List<HashMap<String, String>> data = given().header("sessionID", "12345")
+                                                    .parameters("currentUser", grantee, "userGroups", userGroups)
+                                                    .get(BUCKETS_GRANTS_RESOURCE)
+                                                    .then()
+                                                    .statusCode(HttpStatus.SC_OK)
+                                                    .extract()
+                                                    .path("");
+
+        assertEquals(1, data.size());
+        assertEquals(grantee, data.get(0).get("grantee"));
+        assertEquals("user", data.get(0).get("granteeType"));
+        assertEquals(accessType, data.get(0).get("accessType"));
+        assertEquals(currentUser, data.get(0).get("creator"));
+    }
+}

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -900,7 +900,9 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .then()
                .assertThat()
                .statusCode(HttpStatus.SC_NOT_FOUND)
-               .body(ERROR_MESSAGE, equalTo(new BucketNotFoundException("non-existing-bucket").getLocalizedMessage()));
+               .body(ERROR_MESSAGE,
+                     equalTo(new CatalogObjectNotFoundException("non-existing-bucket",
+                                                                "object-name").getLocalizedMessage()));
     }
 
     @Test
@@ -912,7 +914,9 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                .then()
                .assertThat()
                .statusCode(HttpStatus.SC_NOT_FOUND)
-               .body(ERROR_MESSAGE, equalTo(new BucketNotFoundException("non-existing-bucket").getLocalizedMessage()));
+               .body(ERROR_MESSAGE,
+                     equalTo(new CatalogObjectNotFoundException("non-existing-bucket",
+                                                                "object-name").getLocalizedMessage()));
     }
 
     @Test

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantControllerIntegrationTest.java
@@ -1,0 +1,303 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.rest.controller;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ow2.proactive.catalog.Application;
+import org.ow2.proactive.catalog.dto.BucketMetadata;
+import org.ow2.proactive.catalog.util.IntegrationTestUtil;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.jayway.restassured.response.Response;
+
+
+/**
+ * @author ActiveEon Team
+ */
+@ActiveProfiles("test")
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { Application.class })
+@WebIntegrationTest(randomPort = true)
+public class CatalogObjectGrantControllerIntegrationTest extends AbstractRestAssuredTest {
+
+    private final String bucketName = "test";
+
+    private final String catalogObjectName = "object";
+
+    private final String currentUser = "admin";
+
+    private final String grantee = "user";
+
+    private final String accessType = "read";
+
+    @Before
+    public void setup() {
+        HashMap<String, Object> result = given().header("sessionID", "12345")
+                                                .parameters("name", bucketName, "owner", currentUser)
+                                                .when()
+                                                .post(BUCKETS_RESOURCE)
+                                                .then()
+                                                .statusCode(HttpStatus.SC_CREATED)
+                                                .extract()
+                                                .path("");
+
+        BucketMetadata bucket = new BucketMetadata((String) result.get("name"), (String) result.get("owner"));
+
+        // Add an object of kind "workflow" into first bucket
+        given().header("sessionID", "12345")
+               .pathParam("bucketName", bucket.getName())
+               .queryParam("kind", "workflow")
+               .queryParam("name", catalogObjectName)
+               .queryParam("commitMessage", "commit message")
+               .queryParam("objectContentType", MediaType.APPLICATION_XML.toString())
+               .multiPart(IntegrationTestUtil.getWorkflowFile("workflow.xml"))
+               .when()
+               .post(CATALOG_OBJECTS_RESOURCE)
+               .then()
+               .statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @After
+    public void cleanup() {
+        IntegrationTestUtil.clearObjectGrants();
+        IntegrationTestUtil.cleanup();
+    }
+
+    @Test
+    public void testCreateCatalogObjectGrantForSpecificUserShouldReturnSavedGrant() {
+        Response createCatalogObjectGrantResponse = given().header("sessionID", "12345")
+                                                           .pathParam("bucketName", bucketName)
+                                                           .pathParam("catalogObjectName", catalogObjectName)
+                                                           .parameters("currentUser",
+                                                                       currentUser,
+                                                                       "accessType",
+                                                                       accessType,
+                                                                       "username",
+                                                                       grantee)
+                                                           .when()
+                                                           .post(CATALOG_OBJECT_GRANTS_RESOURCE);
+
+        createCatalogObjectGrantResponse.then()
+                                        .assertThat()
+                                        .body("granteeType", is("user"))
+                                        .body("grantee", is(grantee))
+                                        .body("creator", is(currentUser));
+    }
+
+    @Test
+    public void testCreateCatalogObjectGrantForSpecificGroupShouldReturnSavedGrant() {
+        Response createCatalogObjectGrantResponse = given().header("sessionID", "12345")
+                                                           .pathParam("bucketName", bucketName)
+                                                           .pathParam("catalogObjectName", catalogObjectName)
+                                                           .parameters("currentUser",
+                                                                       currentUser,
+                                                                       "accessType",
+                                                                       accessType,
+                                                                       "userGroup",
+                                                                       grantee)
+                                                           .when()
+                                                           .post(CATALOG_OBJECT_GRANTS_RESOURCE);
+
+        createCatalogObjectGrantResponse.then()
+                                        .assertThat()
+                                        .body("granteeType", is("group"))
+                                        .body("grantee", is(grantee))
+                                        .body("creator", is(currentUser));
+    }
+
+    @Test
+    public void testUpdateCatalogObjectGrantForSpecificUserShouldReturnUpdatedGrant() {
+        Response createCatalogObjectGrantResponse = given().header("sessionID", "12345")
+                                                           .pathParam("bucketName", bucketName)
+                                                           .pathParam("catalogObjectName", catalogObjectName)
+                                                           .parameters("currentUser",
+                                                                       currentUser,
+                                                                       "accessType",
+                                                                       accessType,
+                                                                       "username",
+                                                                       grantee)
+                                                           .when()
+                                                           .post(CATALOG_OBJECT_GRANTS_RESOURCE);
+
+        createCatalogObjectGrantResponse.then()
+                                        .assertThat()
+                                        .body("granteeType", is("user"))
+                                        .body("grantee", is(grantee))
+                                        .body("creator", is(currentUser));
+
+        Response updateCatalogObjectGrantResponse = given().header("sessionID", "12345")
+                                                           .pathParam("bucketName", bucketName)
+                                                           .pathParam("catalogObjectName", catalogObjectName)
+                                                           .parameters("currentUser",
+                                                                       currentUser,
+                                                                       "accessType",
+                                                                       "admin",
+                                                                       "username",
+                                                                       grantee)
+                                                           .when()
+                                                           .put(CATALOG_OBJECT_GRANTS_RESOURCE);
+
+        updateCatalogObjectGrantResponse.then()
+                                        .assertThat()
+                                        .statusCode(HttpStatus.SC_OK)
+                                        .body("granteeType", is("user"))
+                                        .body("grantee", is(grantee))
+                                        .body("creator", is(currentUser))
+                                        .body("accessType", not(accessType));
+    }
+
+    @Test
+    public void testUpdateCatalogObjectGrantForSpecificGroupShouldReturnUpdatedGrant() {
+        Response createCatalogObjectGrantResponse = given().header("sessionID", "12345")
+                                                           .pathParam("bucketName", bucketName)
+                                                           .pathParam("catalogObjectName", catalogObjectName)
+                                                           .parameters("currentUser",
+                                                                       currentUser,
+                                                                       "accessType",
+                                                                       accessType,
+                                                                       "userGroup",
+                                                                       grantee)
+                                                           .when()
+                                                           .post(CATALOG_OBJECT_GRANTS_RESOURCE);
+
+        createCatalogObjectGrantResponse.then()
+                                        .assertThat()
+                                        .body("granteeType", is("group"))
+                                        .body("grantee", is(grantee))
+                                        .body("creator", is(currentUser));
+
+        Response updateCatalogObjectGrantResponse = given().header("sessionID", "12345")
+                                                           .pathParam("bucketName", bucketName)
+                                                           .pathParam("catalogObjectName", catalogObjectName)
+                                                           .parameters("currentUser",
+                                                                       currentUser,
+                                                                       "accessType",
+                                                                       "admin",
+                                                                       "userGroup",
+                                                                       grantee)
+                                                           .when()
+                                                           .put(CATALOG_OBJECT_GRANTS_RESOURCE);
+
+        updateCatalogObjectGrantResponse.then()
+                                        .assertThat()
+                                        .statusCode(HttpStatus.SC_OK)
+                                        .body("granteeType", is("group"))
+                                        .body("grantee", is(grantee))
+                                        .body("creator", is(currentUser))
+                                        .body("accessType", not(accessType));
+    }
+
+    @Test
+    public void testGetAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup() {
+        Response createCatalogObjectGrantResponse = given().header("sessionID", "12345")
+                                                           .pathParam("bucketName", bucketName)
+                                                           .pathParam("catalogObjectName", catalogObjectName)
+                                                           .parameters("currentUser",
+                                                                       currentUser,
+                                                                       "accessType",
+                                                                       accessType,
+                                                                       "username",
+                                                                       grantee)
+                                                           .when()
+                                                           .post(CATALOG_OBJECT_GRANTS_RESOURCE);
+
+        createCatalogObjectGrantResponse.then()
+                                        .assertThat()
+                                        .body("granteeType", is("user"))
+                                        .body("grantee", is(grantee))
+                                        .body("creator", is(currentUser));
+
+        List<HashMap<String, String>> data = given().header("sessionID", "12345")
+                                                    .pathParam("bucketName", bucketName)
+                                                    .pathParam("catalogObjectName", catalogObjectName)
+                                                    .parameters("currentUser", grantee, "userGroup", "group")
+                                                    .get(CATALOG_OBJECT_GRANTS_RESOURCE)
+                                                    .then()
+                                                    .statusCode(HttpStatus.SC_OK)
+                                                    .extract()
+                                                    .path("");
+
+        assertEquals(1, data.size());
+        assertEquals(grantee, data.get(0).get("grantee"));
+        assertEquals("user", data.get(0).get("granteeType"));
+        assertEquals(accessType, data.get(0).get("accessType"));
+        assertEquals(currentUser, data.get(0).get("creator"));
+    }
+
+    @Test
+    public void testGetAllCreatedCatalogObjectGrantsByTheCurrentUserForTheCurrentUserBucket() {
+        Response createCatalogObjectGrantResponse = given().header("sessionID", "12345")
+                                                           .pathParam("bucketName", bucketName)
+                                                           .pathParam("catalogObjectName", catalogObjectName)
+                                                           .parameters("currentUser",
+                                                                       currentUser,
+                                                                       "accessType",
+                                                                       accessType,
+                                                                       "username",
+                                                                       grantee)
+                                                           .when()
+                                                           .post(CATALOG_OBJECT_GRANTS_RESOURCE);
+
+        createCatalogObjectGrantResponse.then()
+                                        .assertThat()
+                                        .body("granteeType", is("user"))
+                                        .body("grantee", is(grantee))
+                                        .body("creator", is(currentUser));
+
+        // CATALOG_OBJECTS_GRANTS_RESOURCE
+
+        List<HashMap<String, String>> data = given().header("sessionID", "12345")
+                                                    .pathParam("bucketName", bucketName)
+                                                    .parameters("currentUser", currentUser)
+                                                    .get(CATALOG_OBJECTS_GRANTS_RESOURCE)
+                                                    .then()
+                                                    .statusCode(HttpStatus.SC_OK)
+                                                    .extract()
+                                                    .path("");
+
+        assertEquals(1, data.size());
+        assertEquals(grantee, data.get(0).get("grantee"));
+        assertEquals("user", data.get(0).get("granteeType"));
+        assertEquals(accessType, data.get(0).get("accessType"));
+        assertEquals(currentUser, data.get(0).get("creator"));
+    }
+}

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectReportControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectReportControllerIntegrationTest.java
@@ -38,11 +38,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ow2.proactive.catalog.Application;
+import org.ow2.proactive.catalog.IntegrationTestConfig;
 import org.ow2.proactive.catalog.dto.BucketMetadata;
 import org.ow2.proactive.catalog.util.IntegrationTestUtil;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 

--- a/src/main/java/org/ow2/proactive/catalog/dto/BucketGrantMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/BucketGrantMetadata.java
@@ -25,13 +25,15 @@
  */
 package org.ow2.proactive.catalog.dto;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import org.ow2.proactive.catalog.repository.entity.BucketGrantEntity;
 import org.springframework.hateoas.ResourceSupport;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
 
 @Data
 @Getter

--- a/src/main/java/org/ow2/proactive/catalog/dto/BucketGrantMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/BucketGrantMetadata.java
@@ -25,14 +25,17 @@
  */
 package org.ow2.proactive.catalog.dto;
 
-import java.util.Objects;
-
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.ow2.proactive.catalog.repository.entity.BucketGrantEntity;
 import org.springframework.hateoas.ResourceSupport;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-
+@Data
+@Getter
+@EqualsAndHashCode(callSuper = false)
 public class BucketGrantMetadata extends ResourceSupport {
 
     @JsonProperty
@@ -64,46 +67,5 @@ public class BucketGrantMetadata extends ResourceSupport {
         this.profiteer = profiteer;
         this.accessType = accessType;
         this.bucketId = bucketId;
-    }
-
-    public String getGrantee() {
-        return this.grantee;
-    }
-
-    public String getProfiteer() {
-        return profiteer;
-    }
-
-    public String getCreator() {
-        return creator;
-    }
-
-    public String getAccessType() {
-        return accessType;
-    }
-
-    public long getBucketId() {
-        return bucketId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        BucketGrantMetadata that = (BucketGrantMetadata) o;
-        return Objects.equals(this.getBucketId(), that.getBucketId()) &&
-               Objects.equals(this.getProfiteer(), that.getProfiteer()) &&
-               Objects.equals(this.getAccessType(), that.getAccessType());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), grantee, profiteer, accessType, bucketId);
     }
 }

--- a/src/main/java/org/ow2/proactive/catalog/dto/BucketGrantMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/BucketGrantMetadata.java
@@ -1,0 +1,109 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.dto;
+
+import java.util.Objects;
+
+import org.ow2.proactive.catalog.repository.entity.BucketGrantEntity;
+import org.springframework.hateoas.ResourceSupport;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class BucketGrantMetadata extends ResourceSupport {
+
+    @JsonProperty
+    private final String grantee;
+
+    @JsonProperty
+    private final String creator;
+
+    @JsonProperty
+    private final String profiteer;
+
+    @JsonProperty
+    private final String accessType;
+
+    @JsonProperty
+    private final long bucketId;
+
+    public BucketGrantMetadata(BucketGrantEntity bucketGrantEntity) {
+        this.grantee = bucketGrantEntity.getGrantee();
+        this.creator = bucketGrantEntity.getCreator();
+        this.profiteer = bucketGrantEntity.getProfiteer();
+        this.accessType = bucketGrantEntity.getAccessType();
+        this.bucketId = bucketGrantEntity.getBucketEntity().getId();
+    }
+
+    public BucketGrantMetadata(String grantee, String creator, String profiteer, String accessType, long bucketId) {
+        this.grantee = grantee;
+        this.creator = creator;
+        this.profiteer = profiteer;
+        this.accessType = accessType;
+        this.bucketId = bucketId;
+    }
+
+    public String getGrantee() {
+        return this.grantee;
+    }
+
+    public String getProfiteer() {
+        return profiteer;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public String getAccessType() {
+        return accessType;
+    }
+
+    public long getBucketId() {
+        return bucketId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BucketGrantMetadata that = (BucketGrantMetadata) o;
+        return Objects.equals(this.getBucketId(), that.getBucketId()) &&
+               Objects.equals(this.getProfiteer(), that.getProfiteer()) &&
+               Objects.equals(this.getAccessType(), that.getAccessType());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), grantee, profiteer, accessType, bucketId);
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/dto/BucketGrantMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/BucketGrantMetadata.java
@@ -41,13 +41,13 @@ import lombok.Getter;
 public class BucketGrantMetadata extends ResourceSupport {
 
     @JsonProperty
-    private final String grantee;
+    private final String granteeType;
 
     @JsonProperty
     private final String creator;
 
     @JsonProperty
-    private final String profiteer;
+    private final String grantee;
 
     @JsonProperty
     private final String accessType;
@@ -56,17 +56,17 @@ public class BucketGrantMetadata extends ResourceSupport {
     private final long bucketId;
 
     public BucketGrantMetadata(BucketGrantEntity bucketGrantEntity) {
-        this.grantee = bucketGrantEntity.getGrantee();
+        this.granteeType = bucketGrantEntity.getGranteeType();
         this.creator = bucketGrantEntity.getCreator();
-        this.profiteer = bucketGrantEntity.getProfiteer();
+        this.grantee = bucketGrantEntity.getGrantee();
         this.accessType = bucketGrantEntity.getAccessType();
         this.bucketId = bucketGrantEntity.getBucketEntity().getId();
     }
 
-    public BucketGrantMetadata(String grantee, String creator, String profiteer, String accessType, long bucketId) {
-        this.grantee = grantee;
+    public BucketGrantMetadata(String granteeType, String creator, String grantee, String accessType, long bucketId) {
+        this.granteeType = granteeType;
         this.creator = creator;
-        this.profiteer = profiteer;
+        this.grantee = grantee;
         this.accessType = accessType;
         this.bucketId = bucketId;
     }

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetaData.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetaData.java
@@ -1,0 +1,120 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.dto;
+
+import java.util.Objects;
+
+import org.ow2.proactive.catalog.repository.entity.CatalogObjectGrantEntity;
+import org.springframework.hateoas.ResourceSupport;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class CatalogObjectGrantMetaData extends ResourceSupport {
+
+    @JsonProperty
+    private final String grantee;
+
+    @JsonProperty
+    private final String creator;
+
+    @JsonProperty
+    private final String profiteer;
+
+    @JsonProperty
+    private final String accessType;
+
+    @JsonProperty
+    private final long catalogObjectId;
+
+    @JsonProperty
+    private final long catalogObjectBucketId;
+
+    public CatalogObjectGrantMetaData(String grantee, String creator, String profiteer, String accessType,
+            long catalogObjectId, long catalogObjectBucketId) {
+        this.grantee = grantee;
+        this.creator = creator;
+        this.profiteer = profiteer;
+        this.accessType = accessType;
+        this.catalogObjectId = catalogObjectId;
+        this.catalogObjectBucketId = catalogObjectBucketId;
+    }
+
+    public CatalogObjectGrantMetaData(CatalogObjectGrantEntity catalogObjectGrantEntity) {
+        this.grantee = catalogObjectGrantEntity.getGrantee();
+        this.creator = catalogObjectGrantEntity.getCreator();
+        this.profiteer = catalogObjectGrantEntity.getProfiteer();
+        this.accessType = catalogObjectGrantEntity.getAccessType();
+        this.catalogObjectId = catalogObjectGrantEntity.getCatalogObjectRevisionEntity().getId();
+        this.catalogObjectBucketId = catalogObjectGrantEntity.getBucketEntity().getId();
+    }
+
+    public String getGrantee() {
+        return grantee;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public String getProfiteer() {
+        return profiteer;
+    }
+
+    public String getAccessType() {
+        return accessType;
+    }
+
+    public long getCatalogObjectId() {
+        return catalogObjectId;
+    }
+
+    public long getCatalogObjectBucketId() {
+        return catalogObjectBucketId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CatalogObjectGrantMetaData that = (CatalogObjectGrantMetaData) o;
+        return Objects.equals(this.getCatalogObjectId(), that.getCatalogObjectId()) &&
+               Objects.equals(this.getProfiteer(), that.getProfiteer()) &&
+               Objects.equals(this.getAccessType(), that.getAccessType()) &&
+               Objects.equals(this.getGrantee(), that.getGrantee()) &&
+               Objects.equals(this.getCatalogObjectBucketId(), that.getCatalogObjectBucketId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), grantee, profiteer, accessType, catalogObjectId, catalogObjectBucketId);
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetadata.java
@@ -41,13 +41,13 @@ import lombok.Getter;
 public class CatalogObjectGrantMetadata extends ResourceSupport {
 
     @JsonProperty
-    private final String grantee;
+    private final String granteeType;
 
     @JsonProperty
     private final String creator;
 
     @JsonProperty
-    private final String profiteer;
+    private final String grantee;
 
     @JsonProperty
     private final String accessType;
@@ -58,20 +58,20 @@ public class CatalogObjectGrantMetadata extends ResourceSupport {
     @JsonProperty
     private final long catalogObjectBucketId;
 
-    public CatalogObjectGrantMetadata(String grantee, String creator, String profiteer, String accessType,
+    public CatalogObjectGrantMetadata(String granteeType, String creator, String grantee, String accessType,
             long catalogObjectId, long catalogObjectBucketId) {
-        this.grantee = grantee;
+        this.granteeType = granteeType;
         this.creator = creator;
-        this.profiteer = profiteer;
+        this.grantee = grantee;
         this.accessType = accessType;
         this.catalogObjectId = catalogObjectId;
         this.catalogObjectBucketId = catalogObjectBucketId;
     }
 
     public CatalogObjectGrantMetadata(CatalogObjectGrantEntity catalogObjectGrantEntity) {
-        this.grantee = catalogObjectGrantEntity.getGrantee();
+        this.granteeType = catalogObjectGrantEntity.getGranteeType();
         this.creator = catalogObjectGrantEntity.getCreator();
-        this.profiteer = catalogObjectGrantEntity.getProfiteer();
+        this.grantee = catalogObjectGrantEntity.getGrantee();
         this.accessType = catalogObjectGrantEntity.getAccessType();
         this.catalogObjectId = catalogObjectGrantEntity.getCatalogObjectRevisionEntity().getId();
         this.catalogObjectBucketId = catalogObjectGrantEntity.getBucketEntity().getId();

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetadata.java
@@ -25,13 +25,15 @@
  */
 package org.ow2.proactive.catalog.dto;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectGrantEntity;
 import org.springframework.hateoas.ResourceSupport;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
 
 @Data
 @Getter
@@ -57,7 +59,7 @@ public class CatalogObjectGrantMetadata extends ResourceSupport {
     private final long catalogObjectBucketId;
 
     public CatalogObjectGrantMetadata(String grantee, String creator, String profiteer, String accessType,
-                                      long catalogObjectId, long catalogObjectBucketId) {
+            long catalogObjectId, long catalogObjectBucketId) {
         this.grantee = grantee;
         this.creator = creator;
         this.profiteer = profiteer;

--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetadata.java
@@ -25,15 +25,18 @@
  */
 package org.ow2.proactive.catalog.dto;
 
-import java.util.Objects;
-
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectGrantEntity;
 import org.springframework.hateoas.ResourceSupport;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-
-public class CatalogObjectGrantMetaData extends ResourceSupport {
+@Data
+@Getter
+@EqualsAndHashCode(callSuper = false)
+public class CatalogObjectGrantMetadata extends ResourceSupport {
 
     @JsonProperty
     private final String grantee;
@@ -53,8 +56,8 @@ public class CatalogObjectGrantMetaData extends ResourceSupport {
     @JsonProperty
     private final long catalogObjectBucketId;
 
-    public CatalogObjectGrantMetaData(String grantee, String creator, String profiteer, String accessType,
-            long catalogObjectId, long catalogObjectBucketId) {
+    public CatalogObjectGrantMetadata(String grantee, String creator, String profiteer, String accessType,
+                                      long catalogObjectId, long catalogObjectBucketId) {
         this.grantee = grantee;
         this.creator = creator;
         this.profiteer = profiteer;
@@ -63,7 +66,7 @@ public class CatalogObjectGrantMetaData extends ResourceSupport {
         this.catalogObjectBucketId = catalogObjectBucketId;
     }
 
-    public CatalogObjectGrantMetaData(CatalogObjectGrantEntity catalogObjectGrantEntity) {
+    public CatalogObjectGrantMetadata(CatalogObjectGrantEntity catalogObjectGrantEntity) {
         this.grantee = catalogObjectGrantEntity.getGrantee();
         this.creator = catalogObjectGrantEntity.getCreator();
         this.profiteer = catalogObjectGrantEntity.getProfiteer();
@@ -72,49 +75,4 @@ public class CatalogObjectGrantMetaData extends ResourceSupport {
         this.catalogObjectBucketId = catalogObjectGrantEntity.getBucketEntity().getId();
     }
 
-    public String getGrantee() {
-        return grantee;
-    }
-
-    public String getCreator() {
-        return creator;
-    }
-
-    public String getProfiteer() {
-        return profiteer;
-    }
-
-    public String getAccessType() {
-        return accessType;
-    }
-
-    public long getCatalogObjectId() {
-        return catalogObjectId;
-    }
-
-    public long getCatalogObjectBucketId() {
-        return catalogObjectBucketId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        CatalogObjectGrantMetaData that = (CatalogObjectGrantMetaData) o;
-        return Objects.equals(this.getCatalogObjectId(), that.getCatalogObjectId()) &&
-               Objects.equals(this.getProfiteer(), that.getProfiteer()) &&
-               Objects.equals(this.getAccessType(), that.getAccessType()) &&
-               Objects.equals(this.getGrantee(), that.getGrantee()) &&
-               Objects.equals(this.getCatalogObjectBucketId(), that.getCatalogObjectBucketId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), grantee, profiteer, accessType, catalogObjectId, catalogObjectBucketId);
-    }
 }

--- a/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
@@ -38,10 +38,9 @@ import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 public interface BucketGrantRepository extends JpaRepository<BucketGrantEntity, Long>,
         JpaSpecificationExecutor<BucketGrantEntity>, QueryDslPredicateExecutor<BucketGrantEntity> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1")
-    List<BucketGrantEntity> findAllGrantsByBucket(long bucketId);
+    List<BucketGrantEntity> findBucketGrantEntitiesByBucketEntityId(long bucketId);
+
+    List<BucketGrantEntity> findBucketGrantEntitiesByCreator(String creatorName);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
@@ -52,11 +51,6 @@ public interface BucketGrantRepository extends JpaRepository<BucketGrantEntity, 
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
     @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1 AND bge.profiteer = ?2 AND bge.grantee='group'")
     BucketGrantEntity findBucketGrantByUserGroup(long bucketId, String userGroup);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.creator = ?1")
-    List<BucketGrantEntity> findAllGrantsCreatedByUsername(String admin);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })

--- a/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
@@ -44,22 +44,22 @@ public interface BucketGrantRepository extends JpaRepository<BucketGrantEntity, 
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1 AND bge.profiteer = ?2 AND bge.grantee='user'")
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1 AND bge.grantee = ?2 AND bge.granteeType='user'")
     BucketGrantEntity findBucketGrantByUsername(long bucketId, String username);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1 AND bge.profiteer = ?2 AND bge.grantee='group'")
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1 AND bge.grantee = ?2 AND bge.granteeType='group'")
     BucketGrantEntity findBucketGrantByUserGroup(long bucketId, String userGroup);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.profiteer = ?1 And bge.grantee='user'")
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee = ?1 And bge.granteeType='user'")
     List<BucketGrantEntity> findAllGrantsAssignedToAUsername(String username);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.profiteer = ?1 And bge.grantee='group'")
-    List<BucketGrantEntity> findAllGrantsAssignedToAUserGroup(String userGroup);
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee in ?1 And bge.granteeType='group'")
+    List<BucketGrantEntity> findAllGrantsAssignedToTheUserGroups(List<String> userGroup);
 
 }

--- a/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
@@ -1,0 +1,71 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.repository;
+
+import java.util.List;
+
+import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
+
+import org.ow2.proactive.catalog.repository.entity.BucketGrantEntity;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.querydsl.QueryDslPredicateExecutor;
+
+
+public interface BucketGrantRepository extends JpaRepository<BucketGrantEntity, Long>,
+        JpaSpecificationExecutor<BucketGrantEntity>, QueryDslPredicateExecutor<BucketGrantEntity> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1")
+    List<BucketGrantEntity> findAllGrantsByBucket(long bucketId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1 AND bge.profiteer = ?2 AND bge.grantee='user'")
+    BucketGrantEntity findBucketGrantByUsername(long bucketId, String username);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1 AND bge.profiteer = ?2 AND bge.grantee='group'")
+    BucketGrantEntity findBucketGrantByUserGroup(long bucketId, String userGroup);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.creator = ?1")
+    List<BucketGrantEntity> findAllGrantsCreatedByUsername(String admin);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.profiteer = ?1 And bge.grantee='user'")
+    List<BucketGrantEntity> findAllGrantsAssignedToAUsername(String username);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.profiteer = ?1 And bge.grantee='group'")
+    List<BucketGrantEntity> findAllGrantsAssignedToAUserGroup(String userGroup);
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
@@ -38,9 +38,11 @@ import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 public interface CatalogObjectGrantRepository extends JpaRepository<CatalogObjectGrantEntity, Long>,
         JpaSpecificationExecutor<CatalogObjectGrantEntity>, QueryDslPredicateExecutor<CatalogObjectGrantEntity> {
 
-    List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(long catalogObjectId, long bucketId);
+    List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(
+            long catalogObjectId, long bucketId);
 
-    List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(String admin, long bucketId);
+    List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(String admin,
+            long bucketId);
 
     List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByBucketEntityId(long bucketId);
 

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
@@ -1,0 +1,89 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.repository;
+
+import java.util.List;
+
+import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
+
+import org.ow2.proactive.catalog.repository.entity.CatalogObjectGrantEntity;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.querydsl.QueryDslPredicateExecutor;
+
+
+public interface CatalogObjectGrantRepository extends JpaRepository<CatalogObjectGrantEntity, Long>,
+        JpaSpecificationExecutor<CatalogObjectGrantEntity>, QueryDslPredicateExecutor<CatalogObjectGrantEntity> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.bucketEntity.id = ?2")
+    List<CatalogObjectGrantEntity> findAllGrantsByCatalogObjectIdInBucket(long catalogObjectId, long bucketId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.profiteer = ?2 AND coge.bucketEntity.id=?3 AND coge.grantee='user'")
+    CatalogObjectGrantEntity findCatalogObjectGrantByUsername(long catalogObjectId, String username, long bucketId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.profiteer = ?2 AND coge.bucketEntity.id=?3 AND coge.grantee='group'")
+    CatalogObjectGrantEntity findCatalogObjectGrantByUserGroup(long catalogObjectId, String userGroup, long bucketId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.creator = ?1 AND coge.bucketEntity.id = ?2")
+    List<CatalogObjectGrantEntity> findAllCatalogObjectsGrantsCreatedByUsernameInASpecificBucket(String admin,
+            long bucketId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.catalogObjectRevisionEntity.id = ?2 AND coge.bucketEntity.id=?3 And coge.grantee='user'")
+    List<CatalogObjectGrantEntity> findAllCatalogObjectGrantsAssignedToAUsername(String username, long catalogObjectId,
+            long bucketId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.catalogObjectRevisionEntity.id = ?2 AND coge.bucketEntity.id=?3 And coge.grantee='group'")
+    List<CatalogObjectGrantEntity> findAllCatalogObjectGrantsAssignedToAUserGroup(String userGroup,
+            long catalogObjectId, long bucketId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge.bucketEntity.id FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.grantee='user'")
+    List<Long> findAllBucketsIdFromCatalogObjectGrantsAssignedToAUsername(String username);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge.bucketEntity.id FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.grantee='group'")
+    List<Long> findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(String userGroup);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.bucketEntity.id=?1")
+    List<CatalogObjectGrantEntity> findAllCatalogObjectGrantsAssignedToABucket(long bucketId);
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
@@ -38,10 +38,11 @@ import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 public interface CatalogObjectGrantRepository extends JpaRepository<CatalogObjectGrantEntity, Long>,
         JpaSpecificationExecutor<CatalogObjectGrantEntity>, QueryDslPredicateExecutor<CatalogObjectGrantEntity> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.bucketEntity.id = ?2")
-    List<CatalogObjectGrantEntity> findAllGrantsByCatalogObjectIdInBucket(long catalogObjectId, long bucketId);
+    List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(long catalogObjectId, long bucketId);
+
+    List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(String admin, long bucketId);
+
+    List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByBucketEntityId(long bucketId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
@@ -52,12 +53,6 @@ public interface CatalogObjectGrantRepository extends JpaRepository<CatalogObjec
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
     @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.profiteer = ?2 AND coge.bucketEntity.id=?3 AND coge.grantee='group'")
     CatalogObjectGrantEntity findCatalogObjectGrantByUserGroup(long catalogObjectId, String userGroup, long bucketId);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.creator = ?1 AND coge.bucketEntity.id = ?2")
-    List<CatalogObjectGrantEntity> findAllCatalogObjectsGrantsCreatedByUsernameInASpecificBucket(String admin,
-            long bucketId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
@@ -80,10 +75,5 @@ public interface CatalogObjectGrantRepository extends JpaRepository<CatalogObjec
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
     @Query(value = "SELECT coge.bucketEntity.id FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.grantee='group'")
     List<Long> findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(String userGroup);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.bucketEntity.id=?1")
-    List<CatalogObjectGrantEntity> findAllCatalogObjectGrantsAssignedToABucket(long bucketId);
 
 }

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
@@ -48,34 +48,34 @@ public interface CatalogObjectGrantRepository extends JpaRepository<CatalogObjec
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.profiteer = ?2 AND coge.bucketEntity.id=?3 AND coge.grantee='user'")
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.grantee = ?2 AND coge.bucketEntity.id=?3 AND coge.granteeType='user'")
     CatalogObjectGrantEntity findCatalogObjectGrantByUsername(long catalogObjectId, String username, long bucketId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.profiteer = ?2 AND coge.bucketEntity.id=?3 AND coge.grantee='group'")
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObjectRevisionEntity.id = ?1 AND coge.grantee = ?2 AND coge.bucketEntity.id=?3 AND coge.granteeType='group'")
     CatalogObjectGrantEntity findCatalogObjectGrantByUserGroup(long catalogObjectId, String userGroup, long bucketId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.catalogObjectRevisionEntity.id = ?2 AND coge.bucketEntity.id=?3 And coge.grantee='user'")
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.grantee = ?1 AND coge.catalogObjectRevisionEntity.id = ?2 AND coge.bucketEntity.id=?3 And coge.granteeType='user'")
     List<CatalogObjectGrantEntity> findAllCatalogObjectGrantsAssignedToAUsername(String username, long catalogObjectId,
             long bucketId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.catalogObjectRevisionEntity.id = ?2 AND coge.bucketEntity.id=?3 And coge.grantee='group'")
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.grantee = ?1 AND coge.catalogObjectRevisionEntity.id = ?2 AND coge.bucketEntity.id=?3 And coge.granteeType='group'")
     List<CatalogObjectGrantEntity> findAllCatalogObjectGrantsAssignedToAUserGroup(String userGroup,
             long catalogObjectId, long bucketId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge.bucketEntity.id FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.grantee='user'")
+    @Query(value = "SELECT coge.bucketEntity.id FROM CatalogObjectGrantEntity coge WHERE coge.grantee = ?1 AND coge.granteeType='user'")
     List<Long> findAllBucketsIdFromCatalogObjectGrantsAssignedToAUsername(String username);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({ @QueryHint(name = "javax.persistence.lock.timeout", value = "5000") })
-    @Query(value = "SELECT coge.bucketEntity.id FROM CatalogObjectGrantEntity coge WHERE coge.profiteer = ?1 AND coge.grantee='group'")
-    List<Long> findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(String userGroup);
+    @Query(value = "SELECT coge.bucketEntity.id FROM CatalogObjectGrantEntity coge WHERE coge.grantee in ?1 AND coge.granteeType='group'")
+    List<Long> findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(List<String> userGroups);
 
 }

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepository.java
@@ -54,6 +54,9 @@ public interface CatalogObjectRevisionRepository extends JpaRepository<CatalogOb
     @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1 AND cor.catalogObject.id.name = ?2 AND cor.catalogObject.lastCommitTime = cor.commitTime")
     CatalogObjectRevisionEntity findDefaultCatalogObjectByNameInBucket(List<String> bucketNames, String name);
 
+    @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.id = ?1")
+    List<CatalogObjectRevisionEntity> findCatalogObject(long catalogObjectId);
+
     @Query("SELECT cor FROM CatalogObjectRevisionEntity cor WHERE cor.catalogObject.bucket.bucketName in ?1 AND cor.catalogObject.id.name = ?2 AND cor.commitTime = ?3")
     CatalogObjectRevisionEntity findCatalogObjectRevisionByCommitTime(List<String> bucketNames, String name,
             long commitTime);

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketEntity.java
@@ -26,9 +26,7 @@
 package org.ow2.proactive.catalog.repository.entity;
 
 import java.io.Serializable;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -82,6 +80,12 @@ public class BucketEntity implements Serializable {
     @Fetch(FetchMode.SELECT)
     @BatchSize(size = 10)
     private Set<CatalogObjectEntity> catalogObjects = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "bucketEntity")
+    private Set<BucketGrantEntity> grants = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "bucketEntity")
+    private Set<CatalogObjectGrantEntity> objectGrants = new LinkedHashSet<>();
 
     public BucketEntity() {
         catalogObjects = new HashSet<>();

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketGrantEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketGrantEntity.java
@@ -54,6 +54,7 @@ public class BucketGrantEntity implements Serializable {
     @Column(name = "ID")
     protected Long id;
 
+    // TODO change to Enum
     // Type of this grant: user or group
     @Column(name = "GRANTEE", nullable = false)
     protected String grantee;

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketGrantEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketGrantEntity.java
@@ -54,19 +54,19 @@ public class BucketGrantEntity implements Serializable {
     @Column(name = "ID")
     protected Long id;
 
-    // Type of this grant: User or Group
+    // Type of this grant: user or group
     @Column(name = "GRANTEE", nullable = false)
     protected String grantee;
 
-    // Type of this grant: User or Group
+    // The User who created this grant
     @Column(name = "CREATOR", nullable = false)
     protected String creator;
 
-    // Username or Group Name
+    // Username or group Name
     @Column(name = "PROFITEER", nullable = false)
     protected String profiteer;
 
-    // Access type: Admin, write or read
+    // Access type: admin, write or read
     @Column(name = "ACCESS_TYPE", nullable = false)
     protected String accessType;
 

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketGrantEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketGrantEntity.java
@@ -42,7 +42,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @Data
 @Entity
-@Table(name = "BUCKET_GRANT", uniqueConstraints = @UniqueConstraint(columnNames = { "ID" }), indexes = { @Index(name = "ID", columnList = "ID") })
+@Table(name = "BUCKET_GRANT", uniqueConstraints = @UniqueConstraint(columnNames = { "ID" }), indexes = { @Index(name = "BUCKET_GRANT_INDEX", columnList = "ID, GRANTEE_TYPE, CREATOR, GRANTEE") })
 @ToString()
 public class BucketGrantEntity implements Serializable {
 
@@ -54,18 +54,17 @@ public class BucketGrantEntity implements Serializable {
     @Column(name = "ID")
     protected Long id;
 
-    // TODO change to Enum
     // Type of this grant: user or group
-    @Column(name = "GRANTEE", nullable = false)
-    protected String grantee;
+    @Column(name = "GRANTEE_TYPE", nullable = false)
+    protected String granteeType;
 
     // The User who created this grant
     @Column(name = "CREATOR", nullable = false)
     protected String creator;
 
     // Username or group Name
-    @Column(name = "PROFITEER", nullable = false)
-    protected String profiteer;
+    @Column(name = "GRANTEE", nullable = false)
+    protected String grantee;
 
     // Access type: admin, write or read
     @Column(name = "ACCESS_TYPE", nullable = false)
@@ -76,11 +75,11 @@ public class BucketGrantEntity implements Serializable {
     @JoinColumn(name = "BUCKET", nullable = false)
     protected BucketEntity bucketEntity;
 
-    public BucketGrantEntity(String grantee, String creator, String profiteer, String accessType,
+    public BucketGrantEntity(String granteeType, String creator, String grantee, String accessType,
             BucketEntity bucketEntity) {
-        this.grantee = grantee;
+        this.granteeType = granteeType;
         this.creator = creator;
-        this.profiteer = profiteer;
+        this.grantee = grantee;
         this.accessType = accessType;
         this.bucketEntity = bucketEntity;
     }

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketGrantEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/BucketGrantEntity.java
@@ -1,0 +1,89 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.repository.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+
+
+/**
+ * @author ActiveEon Team
+ */
+@AllArgsConstructor
+@Data
+@Entity
+@Table(name = "BUCKET_GRANT", uniqueConstraints = @UniqueConstraint(columnNames = { "ID" }), indexes = { @Index(name = "ID", columnList = "ID") })
+@ToString()
+public class BucketGrantEntity implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GRANT_SEQUENCE")
+    @GenericGenerator(name = "GRANT_SEQUENCE", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator", parameters = { @org.hibernate.annotations.Parameter(name = "sequence_name", value = "GRANT_SEQUENCE"),
+                                                                                                                             @org.hibernate.annotations.Parameter(name = "initial_value", value = "1"),
+                                                                                                                             @org.hibernate.annotations.Parameter(name = "increment_size", value = "1") })
+    @Column(name = "ID")
+    protected Long id;
+
+    // Type of this grant: User or Group
+    @Column(name = "GRANTEE", nullable = false)
+    protected String grantee;
+
+    // Type of this grant: User or Group
+    @Column(name = "CREATOR", nullable = false)
+    protected String creator;
+
+    // Username or Group Name
+    @Column(name = "PROFITEER", nullable = false)
+    protected String profiteer;
+
+    // Access type: Admin, write or read
+    @Column(name = "ACCESS_TYPE", nullable = false)
+    protected String accessType;
+
+    // Bucket association
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = BucketEntity.class)
+    @JoinColumn(name = "BUCKET", nullable = false)
+    protected BucketEntity bucketEntity;
+
+    public BucketGrantEntity(String grantee, String creator, String profiteer, String accessType,
+            BucketEntity bucketEntity) {
+        this.grantee = grantee;
+        this.creator = creator;
+        this.profiteer = profiteer;
+        this.accessType = accessType;
+        this.bucketEntity = bucketEntity;
+    }
+
+    public BucketGrantEntity() {
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectGrantEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectGrantEntity.java
@@ -42,7 +42,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @Data
 @Entity
-@Table(name = "CATALOG_OBJECT_GRANT", uniqueConstraints = @UniqueConstraint(columnNames = { "ID" }), indexes = { @Index(name = "ID", columnList = "ID") })
+@Table(name = "CATALOG_OBJECT_GRANT", uniqueConstraints = @UniqueConstraint(columnNames = { "ID" }), indexes = { @Index(name = "OBJECT_GRANT_IBDEX", columnList = "ID, GRANTEE, CREATOR, GRANTEE_TYPE") })
 @ToString()
 public class CatalogObjectGrantEntity implements Serializable {
 
@@ -54,18 +54,17 @@ public class CatalogObjectGrantEntity implements Serializable {
     @Column(name = "ID")
     protected Long id;
 
-    // TODO Change to Enum
     // Type of this grant: user or group
-    @Column(name = "GRANTEE", nullable = false)
-    protected String grantee;
+    @Column(name = "GRANTEE_TYPE", nullable = false)
+    protected String granteeType;
 
     // The User who created this grant
     @Column(name = "CREATOR", nullable = false)
     protected String creator;
 
     // Username or group Name
-    @Column(name = "PROFITEER", nullable = false)
-    protected String profiteer;
+    @Column(name = "GRANTEE", nullable = false)
+    protected String grantee;
 
     // Access type: admin, write or read
     @Column(name = "ACCESS_TYPE", nullable = false)
@@ -83,11 +82,11 @@ public class CatalogObjectGrantEntity implements Serializable {
     public CatalogObjectGrantEntity() {
     }
 
-    public CatalogObjectGrantEntity(String grantee, String creator, String profiteer, String accessType,
+    public CatalogObjectGrantEntity(String granteeType, String creator, String grantee, String accessType,
             CatalogObjectRevisionEntity catalogObjectRevisionEntity, BucketEntity bucketEntity) {
-        this.grantee = grantee;
+        this.granteeType = granteeType;
         this.creator = creator;
-        this.profiteer = profiteer;
+        this.grantee = grantee;
         this.accessType = accessType;
         this.catalogObjectRevisionEntity = catalogObjectRevisionEntity;
         this.bucketEntity = bucketEntity;

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectGrantEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectGrantEntity.java
@@ -54,6 +54,7 @@ public class CatalogObjectGrantEntity implements Serializable {
     @Column(name = "ID")
     protected Long id;
 
+    // TODO Change to Enum
     // Type of this grant: user or group
     @Column(name = "GRANTEE", nullable = false)
     protected String grantee;

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectGrantEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectGrantEntity.java
@@ -54,19 +54,19 @@ public class CatalogObjectGrantEntity implements Serializable {
     @Column(name = "ID")
     protected Long id;
 
-    // Type of this grant: User or Group
+    // Type of this grant: user or group
     @Column(name = "GRANTEE", nullable = false)
     protected String grantee;
 
-    // Type of this grant: User or Group
+    // The User who created this grant
     @Column(name = "CREATOR", nullable = false)
     protected String creator;
 
-    // Username or Group Name
+    // Username or group Name
     @Column(name = "PROFITEER", nullable = false)
     protected String profiteer;
 
-    // Access type: Admin, write or read
+    // Access type: admin, write or read
     @Column(name = "ACCESS_TYPE", nullable = false)
     protected String accessType;
 

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectGrantEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectGrantEntity.java
@@ -1,0 +1,94 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.repository.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+
+
+/**
+ * @author ActiveEon Team
+ */
+@AllArgsConstructor
+@Data
+@Entity
+@Table(name = "CATALOG_OBJECT_GRANT", uniqueConstraints = @UniqueConstraint(columnNames = { "ID" }), indexes = { @Index(name = "ID", columnList = "ID") })
+@ToString()
+public class CatalogObjectGrantEntity implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "CATALOG_OBJECT_GRANT_SEQUENCE")
+    @GenericGenerator(name = "CATALOG_OBJECT_GRANT_SEQUENCE", strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator", parameters = { @org.hibernate.annotations.Parameter(name = "sequence_name", value = "CATALOG_OBJECT_GRANT_SEQUENCE"),
+                                                                                                                                            @org.hibernate.annotations.Parameter(name = "initial_value", value = "1"),
+                                                                                                                                            @org.hibernate.annotations.Parameter(name = "increment_size", value = "1") })
+    @Column(name = "ID")
+    protected Long id;
+
+    // Type of this grant: User or Group
+    @Column(name = "GRANTEE", nullable = false)
+    protected String grantee;
+
+    // Type of this grant: User or Group
+    @Column(name = "CREATOR", nullable = false)
+    protected String creator;
+
+    // Username or Group Name
+    @Column(name = "PROFITEER", nullable = false)
+    protected String profiteer;
+
+    // Access type: Admin, write or read
+    @Column(name = "ACCESS_TYPE", nullable = false)
+    protected String accessType;
+
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = CatalogObjectRevisionEntity.class)
+    @JoinColumn(name = "CATALOG_OBJECT_REVISION", nullable = false)
+    protected CatalogObjectRevisionEntity catalogObjectRevisionEntity;
+
+    // Bucket association
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = BucketEntity.class)
+    @JoinColumn(name = "BUCKET", nullable = false)
+    protected BucketEntity bucketEntity;
+
+    public CatalogObjectGrantEntity() {
+    }
+
+    public CatalogObjectGrantEntity(String grantee, String creator, String profiteer, String accessType,
+            CatalogObjectRevisionEntity catalogObjectRevisionEntity, BucketEntity bucketEntity) {
+        this.grantee = grantee;
+        this.creator = creator;
+        this.profiteer = profiteer;
+        this.accessType = accessType;
+        this.catalogObjectRevisionEntity = catalogObjectRevisionEntity;
+        this.bucketEntity = bucketEntity;
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectRevisionEntity.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectRevisionEntity.java
@@ -26,9 +26,7 @@
 package org.ow2.proactive.catalog.repository.entity;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 import javax.persistence.*;
 
@@ -91,6 +89,9 @@ public class CatalogObjectRevisionEntity implements Comparable, Serializable {
     @Lob
     @Column(name = "RAW_OBJECT", length = Integer.MAX_VALUE)
     private byte[] rawObject;
+
+    @OneToMany(mappedBy = "catalogObjectRevisionEntity")
+    private Set<CatalogObjectGrantEntity> objectGrants = new LinkedHashSet<>();
 
     @Override
     public int compareTo(Object o) {

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
@@ -25,6 +25,8 @@
  */
 package org.ow2.proactive.catalog.rest.controller;
 
+import static org.ow2.proactive.catalog.util.AccessType.ADMIN_ACCESS_TYPE;
+import static org.ow2.proactive.catalog.util.AccessType.READ_ACCESS_TYPE;
 import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
@@ -34,10 +36,14 @@ import java.util.List;
 import java.util.Optional;
 
 import org.ow2.proactive.catalog.dto.BucketMetadata;
+import org.ow2.proactive.catalog.service.BucketGrantService;
 import org.ow2.proactive.catalog.service.BucketService;
+import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
 import org.ow2.proactive.catalog.service.RestApiAccessService;
 import org.ow2.proactive.catalog.service.exception.AccessDeniedException;
 import org.ow2.proactive.catalog.service.exception.BucketAlreadyExistingException;
+import org.ow2.proactive.catalog.service.exception.BucketGrantAccessException;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
 import org.ow2.proactive.catalog.service.model.RestApiAccessResponse;
 import org.ow2.proactive.microservices.common.exception.NotAuthenticatedException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,6 +77,12 @@ public class BucketController {
 
     @Autowired
     private RestApiAccessService restApiAccessService;
+
+    @Autowired
+    private BucketGrantService bucketGrantService;
+
+    @Autowired
+    private CatalogObjectGrantService catalogObjectGrantService;
 
     @Value("${pa.catalog.security.required.sessionid}")
     private boolean sessionIdRequired;
@@ -110,7 +122,20 @@ public class BucketController {
             @ApiParam(value = "The new name of the user that will own the Bucket") @RequestParam(value = "owner", required = true) String newOwnerName)
             throws NotAuthenticatedException, AccessDeniedException {
         if (sessionIdRequired) {
-            restApiAccessService.checkAccessBySessionIdForOwnerOrGroupAndThrowIfDeclined(sessionId, newOwnerName);
+            // Check session validation
+            if (!restApiAccessService.isSessionActive(sessionId)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+
+            // Check Grants
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
+                                                                                                               bucketName,
+                                                                                                               ADMIN_ACCESS_TYPE)) {
+                    throw new BucketGrantAccessException(bucketName);
+                }
+            }
         }
         try {
             return bucketService.updateOwnerByBucketName(bucketName, newOwnerName);
@@ -128,9 +153,25 @@ public class BucketController {
     public BucketMetadata getMetadata(
             @SuppressWarnings("DefaultAnnotationParam") @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @PathVariable String bucketName) throws NotAuthenticatedException, AccessDeniedException {
-        restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionIdRequired,
-                                                                               sessionId,
-                                                                               bucketName);
+
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isSessionActive(sessionId)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        // Check Grants
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
+                                                                                                           bucketName,
+                                                                                                           READ_ACCESS_TYPE) &&
+                !catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(user,
+                                                                                                     bucketName)) {
+                throw new BucketGrantAccessException(bucketName);
+            }
+        }
         return bucketService.getBucketMetadata(bucketName);
     }
 
@@ -166,6 +207,8 @@ public class BucketController {
                                                           () -> restApiAccessResponse.getAuthenticatedUser()
                                                                                      .getGroups());
 
+            listBucket.addAll(bucketGrantService.getBucketsForUserByGrants(restApiAccessService.getUserFromSessionId(sessionId)));
+
         } else {
             listBucket = bucketService.listBuckets(ownerName, kind, contentType, objectName);
         }
@@ -191,9 +234,20 @@ public class BucketController {
     public BucketMetadata delete(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName) throws NotAuthenticatedException, AccessDeniedException {
-        restApiAccessService.checkAccessBySessionIdForBucketAndThrowIfDeclined(sessionIdRequired,
-                                                                               sessionId,
-                                                                               bucketName);
+        // Check session validation
+        if (!restApiAccessService.isSessionActive(sessionId)) {
+            throw new AccessDeniedException("Session id is not active. Please login.");
+        }
+
+        // Check Grants
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
+                                                                                                           bucketName,
+                                                                                                           ADMIN_ACCESS_TYPE)) {
+                throw new BucketGrantAccessException(bucketName);
+            }
+        }
         return bucketService.deleteEmptyBucket(bucketName);
     }
 }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
@@ -25,8 +25,8 @@
  */
 package org.ow2.proactive.catalog.rest.controller;
 
-import static org.ow2.proactive.catalog.util.AccessType.ADMIN_ACCESS_TYPE;
-import static org.ow2.proactive.catalog.util.AccessType.READ_ACCESS_TYPE;
+import static org.ow2.proactive.catalog.util.AccessType.admin;
+import static org.ow2.proactive.catalog.util.AccessType.read;
 import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
@@ -45,6 +45,7 @@ import org.ow2.proactive.catalog.service.exception.BucketAlreadyExistingExceptio
 import org.ow2.proactive.catalog.service.exception.BucketGrantAccessException;
 import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
 import org.ow2.proactive.catalog.service.model.RestApiAccessResponse;
+import org.ow2.proactive.catalog.util.AccessType;
 import org.ow2.proactive.microservices.common.exception.NotAuthenticatedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -132,7 +133,7 @@ public class BucketController {
                 AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
                 if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                                bucketName,
-                                                                                                               ADMIN_ACCESS_TYPE)) {
+                        admin.toString())) {
                     throw new BucketGrantAccessException(bucketName);
                 }
             }
@@ -166,7 +167,7 @@ public class BucketController {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           READ_ACCESS_TYPE) &&
+                                                                                                           read.toString()) &&
                 !catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(user,
                                                                                                      bucketName)) {
                 throw new BucketGrantAccessException(bucketName);
@@ -244,7 +245,7 @@ public class BucketController {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           ADMIN_ACCESS_TYPE)) {
+                                                                                                           admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
@@ -131,9 +131,7 @@ public class BucketController {
             // Check Grants
             if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
                 AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-                if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
-                                                                                                               bucketName,
-                        admin.toString())) {
+                if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
                     throw new BucketGrantAccessException(bucketName);
                 }
             }
@@ -160,18 +158,17 @@ public class BucketController {
             if (!restApiAccessService.isSessionActive(sessionId)) {
                 throw new AccessDeniedException("Session id is not active. Please login.");
             }
-        }
 
-        // Check Grants
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
-            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
-                                                                                                           bucketName,
-                                                                                                           read.toString()) &&
-                !catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(user,
-                                                                                                     bucketName)) {
-                throw new BucketGrantAccessException(bucketName);
+            // Check Grants
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, read.toString()) &&
+                    !catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(user,
+                                                                                                         bucketName)) {
+                    throw new BucketGrantAccessException(bucketName);
+                }
             }
+
         }
         return bucketService.getBucketMetadata(bucketName);
     }
@@ -236,17 +233,17 @@ public class BucketController {
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName) throws NotAuthenticatedException, AccessDeniedException {
         // Check session validation
-        if (!restApiAccessService.isSessionActive(sessionId)) {
-            throw new AccessDeniedException("Session id is not active. Please login.");
-        }
+        if (sessionIdRequired) {
+            if (!restApiAccessService.isSessionActive(sessionId)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
 
-        // Check Grants
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
-            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
-                                                                                                           bucketName,
-                                                                                                           admin.toString())) {
-                throw new BucketGrantAccessException(bucketName);
+            // Check Grants
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
+                    throw new BucketGrantAccessException(bucketName);
+                }
             }
         }
         return bucketService.deleteEmptyBucket(bucketName);

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
@@ -67,7 +67,7 @@ public class BucketGrantController {
     private boolean sessionIdRequired;
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Get all assigned grants for the user and his group")
+    @ApiOperation(value = "Get all assigned grants for the user and his groups")
     @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
                             @ApiResponse(code = 403, message = "Permission denied"), })
     @RequestMapping(method = GET)

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
@@ -1,0 +1,221 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.rest.controller;
+
+import static org.springframework.web.bind.annotation.RequestMethod.*;
+
+import java.util.List;
+
+import org.ow2.proactive.catalog.dto.BucketGrantMetadata;
+import org.ow2.proactive.catalog.service.BucketGrantService;
+import org.ow2.proactive.catalog.service.RestApiAccessService;
+import org.ow2.proactive.catalog.service.exception.AccessDeniedException;
+import org.ow2.proactive.catalog.service.exception.BucketGrantAccessException;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+import org.ow2.proactive.microservices.common.exception.NotAuthenticatedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.extern.log4j.Log4j2;
+
+
+/**
+ * @author ActiveEon Team
+ */
+@Log4j2
+@RestController
+@RequestMapping(value = "/buckets/grant")
+public class BucketGrantController {
+
+    private final String ADMIN_ACCESS_TYPE = "admin";
+
+    @Autowired
+    private BucketGrantService bucketGrantService;
+
+    @Autowired
+    private RestApiAccessService restApiAccessService;
+
+    @Value("${pa.catalog.security.required.sessionid}")
+    private boolean sessionIdRequired;
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Get all assigned grants for the user and his group")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(method = GET)
+    @ResponseStatus(HttpStatus.OK)
+    public List<BucketGrantMetadata> getAssignedBucketGrantsForUserAndHisGroup(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
+            @ApiParam(value = "The current userGroup") @RequestParam(value = "userGroup", required = true) String userGroup)
+            throws NotAuthenticatedException, AccessDeniedException {
+        if (sessionIdRequired) {
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        return bucketGrantService.getAllAssignedGrantsForUserAndHisGroup(currentUser, userGroup);
+    }
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Update the access type of an existing bucket grant")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(value = "/{bucketName}", method = PUT)
+    @ResponseStatus(HttpStatus.OK)
+    public BucketGrantMetadata updateBucketGrant(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @ApiParam(value = "The user who is updating this grant") @RequestParam(value = "currentUser", required = true) String currentUser,
+            @ApiParam(value = "username", required = false) @RequestHeader(value = "username", required = false) String username,
+            @ApiParam(value = "userGroup", required = false, defaultValue = "") @RequestHeader(value = "userGroup", required = false, defaultValue = "") String userGroup,
+            @ApiParam(value = "accessType", required = true, defaultValue = "") @RequestHeader(value = "accessType", required = true, defaultValue = "") String accessType,
+            @PathVariable String bucketName) throws NotAuthenticatedException, AccessDeniedException {
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        // Check Grants
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
+                                                                                                          bucketName,
+                                                                                                          ADMIN_ACCESS_TYPE)) {
+                throw new BucketGrantAccessException(bucketName);
+            }
+        }
+
+        BucketGrantMetadata result = null;
+
+        if (!username.equals("") && userGroup.equals("")) {
+            // Case if the grant targets a specific user
+            result = bucketGrantService.updateBucketGrantForASpecificUser(bucketName, username, accessType);
+        } else if (username.equals("") && !userGroup.equals("")) {
+            // Case if the grant targets a specific group
+            result = bucketGrantService.updateBucketGrantForASpecificUserGroup(bucketName, userGroup, accessType);
+        }
+        return result;
+
+    }
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Get all created grants by a specific user")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(value = "/{username}", method = GET)
+    @ResponseStatus(HttpStatus.OK)
+    public List<BucketGrantMetadata> getCreatedBucketGrants(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @PathVariable String username) throws NotAuthenticatedException, AccessDeniedException {
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, username)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        return bucketGrantService.getAllGrantsCreatedByUsername(username);
+    }
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Create a new username grant or a user group grant access for a bucket")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(method = POST)
+    @ResponseStatus(HttpStatus.CREATED)
+    public BucketGrantMetadata createBucketGrant(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @ApiParam(value = "The name of the Bucket") @RequestParam(value = "bucketName", required = true) String bucketName,
+            @ApiParam(value = "The user who is creating this grant") @RequestParam(value = "currentUser", required = true) String currentUser,
+            @ApiParam(value = "The access type of the grant") @RequestParam(value = "accessType", required = true) String accessType,
+            @ApiParam(value = "The name of the user that will have grant access", defaultValue = "") @RequestParam(value = "username", required = false, defaultValue = "") String username,
+            @ApiParam(value = "The name of the user group that will have grant access", defaultValue = "") @RequestParam(value = "userGroup", required = false, defaultValue = "") String userGroup)
+            throws NotAuthenticatedException, AccessDeniedException {
+
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        // Check if user is admin or has admin Grants over the bucket
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
+                                                                                                          bucketName,
+                                                                                                          ADMIN_ACCESS_TYPE)) {
+                throw new BucketGrantAccessException(bucketName);
+            }
+        }
+
+        return bucketGrantService.createBucketGrant(bucketName, currentUser, accessType, username, userGroup);
+
+    }
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Delete a grant access for a bucket")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(method = DELETE)
+    @ResponseStatus(HttpStatus.OK)
+    public BucketGrantMetadata deleteBucketGrant(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @ApiParam(value = "The name of the Bucket") @RequestParam(value = "bucketName", required = true) String bucketName,
+            @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
+            @ApiParam(value = "The name of the user that have grant access over this bucket", defaultValue = "") @RequestParam(value = "username", required = false, defaultValue = "") String username,
+            @ApiParam(value = "The name of the user group that have grant access over this bucket", defaultValue = "") @RequestParam(value = "userGroup", required = false, defaultValue = "") String userGroup)
+            throws NotAuthenticatedException, AccessDeniedException {
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        // Check if user is admin or has admin Grants over the bucket
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
+                                                                                                          bucketName,
+                                                                                                          ADMIN_ACCESS_TYPE)) {
+                throw new BucketGrantAccessException(bucketName);
+            }
+        }
+
+        return bucketGrantService.deleteBucketGrant(bucketName, username, userGroup);
+    }
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
@@ -109,19 +109,17 @@ public class BucketGrantController {
         // Check Grants
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
-                                                                                                          bucketName,
-                                                                                                          admin.toString())) {
+            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
 
         BucketGrantMetadata result = null;
 
-        if (!username.equals("") && userGroup.equals("")) {
+        if (!username.isEmpty() && userGroup.isEmpty()) {
             // Case if the grant targets a specific user
             result = bucketGrantService.updateBucketGrantForASpecificUser(bucketName, username, accessType);
-        } else if (username.equals("") && !userGroup.equals("")) {
+        } else if (username.isEmpty() && !userGroup.isEmpty()) {
             // Case if the grant targets a specific group
             result = bucketGrantService.updateBucketGrantForASpecificUserGroup(bucketName, userGroup, accessType);
         }
@@ -173,9 +171,7 @@ public class BucketGrantController {
         // Check if user is admin or has admin Grants over the bucket
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
-                                                                                                          bucketName,
-                                                                                                          admin.toString())) {
+            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
@@ -207,9 +203,7 @@ public class BucketGrantController {
         // Check if user is admin or has admin Grants over the bucket
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
-                                                                                                          bucketName,
-                                                                                                          admin.toString())) {
+            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive.catalog.rest.controller;
 
+import static org.ow2.proactive.catalog.util.AccessType.admin;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
 
 import java.util.List;
@@ -55,8 +56,6 @@ import lombok.extern.log4j.Log4j2;
 @RestController
 @RequestMapping(value = "/buckets/grant")
 public class BucketGrantController {
-
-    private final String ADMIN_ACCESS_TYPE = "admin";
 
     @Autowired
     private BucketGrantService bucketGrantService;
@@ -112,7 +111,7 @@ public class BucketGrantController {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                           bucketName,
-                                                                                                          ADMIN_ACCESS_TYPE)) {
+                                                                                                          admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
@@ -176,7 +175,7 @@ public class BucketGrantController {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                           bucketName,
-                                                                                                          ADMIN_ACCESS_TYPE)) {
+                                                                                                          admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
@@ -210,7 +209,7 @@ public class BucketGrantController {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                           bucketName,
-                                                                                                          ADMIN_ACCESS_TYPE)) {
+                                                                                                          admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
@@ -75,7 +75,7 @@ public class BucketGrantController {
     public List<BucketGrantMetadata> getAssignedBucketGrantsForUserAndHisGroup(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
-            @ApiParam(value = "The current userGroup") @RequestParam(value = "userGroup", required = true) String userGroup)
+            @ApiParam(value = "The list of the current user groups") @RequestParam(value = "userGroups", required = true) List<String> userGroups)
             throws NotAuthenticatedException, AccessDeniedException {
         if (sessionIdRequired) {
             if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
@@ -83,7 +83,7 @@ public class BucketGrantController {
             }
         }
 
-        return bucketGrantService.getAllAssignedGrantsForUserAndHisGroup(currentUser, userGroup);
+        return bucketGrantService.getAllAssignedGrantsForUserAndHisGroups(currentUser, userGroups);
     }
 
     @SuppressWarnings("DefaultAnnotationParam")

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
@@ -95,7 +95,7 @@ public class BucketGrantController {
     public BucketGrantMetadata updateBucketGrant(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @ApiParam(value = "The user who is updating this grant") @RequestParam(value = "currentUser", required = true) String currentUser,
-            @ApiParam(value = "username", required = false) @RequestHeader(value = "username", required = false) String username,
+            @ApiParam(value = "username", required = false, defaultValue = "") @RequestHeader(value = "username", required = false, defaultValue = "") String username,
             @ApiParam(value = "userGroup", required = false, defaultValue = "") @RequestHeader(value = "userGroup", required = false, defaultValue = "") String userGroup,
             @ApiParam(value = "accessType", required = true, defaultValue = "") @RequestHeader(value = "accessType", required = true, defaultValue = "") String accessType,
             @PathVariable String bucketName) throws NotAuthenticatedException, AccessDeniedException {
@@ -104,13 +104,13 @@ public class BucketGrantController {
             if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
                 throw new AccessDeniedException("Session id is not active. Please login.");
             }
-        }
 
-        // Check Grants
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
-            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
-                throw new BucketGrantAccessException(bucketName);
+            // Check Grants
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
+                    throw new BucketGrantAccessException(bucketName);
+                }
             }
         }
 
@@ -166,14 +166,15 @@ public class BucketGrantController {
             if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
                 throw new AccessDeniedException("Session id is not active. Please login.");
             }
-        }
 
-        // Check if user is admin or has admin Grants over the bucket
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
-            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
-                throw new BucketGrantAccessException(bucketName);
+            // Check if user is admin or has admin Grants over the bucket
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
+                    throw new BucketGrantAccessException(bucketName);
+                }
             }
+
         }
 
         return bucketGrantService.createBucketGrant(bucketName, currentUser, accessType, username, userGroup);
@@ -198,13 +199,13 @@ public class BucketGrantController {
             if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
                 throw new AccessDeniedException("Session id is not active. Please login.");
             }
-        }
 
-        // Check if user is admin or has admin Grants over the bucket
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
-            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
-                throw new BucketGrantAccessException(bucketName);
+            // Check if user is admin or has admin Grants over the bucket
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user, bucketName, admin.toString())) {
+                    throw new BucketGrantAccessException(bucketName);
+                }
             }
         }
 

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -133,7 +133,7 @@ public class CatalogObjectController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           ADMIN_ACCESS_TYPE)) {
+                                                                                                           admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
@@ -226,11 +226,11 @@ public class CatalogObjectController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           WRITE_ACCESS_TYPE) &&
+                                                                                                           write.toString()) &&
                 !catalogObjectGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                                       bucketName,
                                                                                                                       name,
-                                                                                                                      WRITE_ACCESS_TYPE)) {
+                                                                                                                      write.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
@@ -261,11 +261,11 @@ public class CatalogObjectController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           READ_ACCESS_TYPE) &&
+                                                                                                           read.toString()) &&
                 !catalogObjectGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                                       bucketName,
                                                                                                                       name,
-                                                                                                                      READ_ACCESS_TYPE)) {
+                                                                                                                      read.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
@@ -300,11 +300,11 @@ public class CatalogObjectController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           READ_ACCESS_TYPE) &&
+                                                                                                           read.toString()) &&
                 !catalogObjectGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                                       bucketName,
                                                                                                                       name,
-                                                                                                                      READ_ACCESS_TYPE)) {
+                                                                                                                      read.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
@@ -338,11 +338,11 @@ public class CatalogObjectController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           READ_ACCESS_TYPE) &&
+                                                                                                           read.toString()) &&
                 !catalogObjectGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                                       bucketName,
                                                                                                                       name,
-                                                                                                                      READ_ACCESS_TYPE)) {
+                                                                                                                      read.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }
@@ -378,12 +378,11 @@ public class CatalogObjectController {
 
         // Check Grants
         AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-        List<CatalogObjectGrantMetaData> grants = new LinkedList<>();
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName) &&
-            !catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(user, bucketName)) {
+        List<CatalogObjectGrantMetadata> grants = new LinkedList<>();
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           READ_ACCESS_TYPE)) {
+                                                                                                           read.toString()) && !catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(user, bucketName)) {
                 throw new BucketGrantAccessException(bucketName);
             } else {
                 grants = catalogObjectGrantService.findAllCatalogObjectGrantsAssignedToABucket(bucketName);
@@ -426,12 +425,24 @@ public class CatalogObjectController {
                                                                                                pageNo,
                                                                                                pageSize);
 
+
+
+            // TODO optimize this algorithm
             if (!grants.isEmpty()) {
-                for (CatalogObjectGrantMetaData grant : grants) {
-                    metadataList.removeIf(obj -> !obj.getName()
-                                                     .equals(catalogObjectGrantService.getCatalogObjectNameFromGrant(grant)) &&
-                                                 grant.getProfiteer().equals(user.getName()));
+                List<CatalogObjectMetadata> objectsToRemove = new LinkedList<>();
+                List<CatalogObjectMetadata> objectsNotToRemove = new LinkedList<>();
+                for (CatalogObjectGrantMetadata grant : grants) {
+                    String objName = catalogObjectGrantService.getCatalogObjectNameFromGrant(grant);
+                    for(CatalogObjectMetadata obj: metadataList){
+                        if(!obj.getName().equals(objName) && !objectsToRemove.contains(obj)){
+                            objectsToRemove.add(obj);
+                        } else if (obj.getName().equals(objName) && !objectsNotToRemove.contains(obj)){
+                            objectsNotToRemove.add(obj);
+                        }
+                    }
                 }
+                objectsToRemove.removeAll(objectsNotToRemove);
+                metadataList.removeAll(objectsToRemove);
             }
 
             for (CatalogObjectMetadata catalogObject : metadataList) {
@@ -465,11 +476,11 @@ public class CatalogObjectController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             if (!bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                            bucketName,
-                                                                                                           ADMIN_ACCESS_TYPE) &&
+                                                                                                           admin.toString()) &&
                 !catalogObjectGrantService.isTheUserGrantSufficientForTheCurrentTask(user,
                                                                                                                       bucketName,
                                                                                                                       name,
-                                                                                                                      ADMIN_ACCESS_TYPE)) {
+                                                                                                                      admin.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
         }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantController.java
@@ -84,15 +84,15 @@ public class CatalogObjectGrantController {
             if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
                 throw new AccessDeniedException("Session id is not active. Please login.");
             }
-        }
 
-        // Check Grants
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
-            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
-                                                                                                                            bucketName,
-                                                                                                                            catalogObjectName)) {
-                throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+            // Check Grants
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
+                                                                                                                                bucketName,
+                                                                                                                                catalogObjectName)) {
+                    throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+                }
             }
         }
 
@@ -124,19 +124,18 @@ public class CatalogObjectGrantController {
             if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
                 throw new AccessDeniedException("Session id is not active. Please login.");
             }
-        }
 
-        // Check Grants
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
-            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
-                                                                                                                            bucketName,
-                                                                                                                            catalogObjectName)) {
-                throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+            // Check Grants
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
+                                                                                                                                bucketName,
+                                                                                                                                catalogObjectName)) {
+                    throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+                }
             }
         }
         return catalogObjectGrantService.deleteCatalogObjectGrant(bucketName, catalogObjectName, username, userGroup);
-
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
@@ -159,15 +158,15 @@ public class CatalogObjectGrantController {
             if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
                 throw new AccessDeniedException("Session id is not active. Please login.");
             }
-        }
 
-        // Check Grants
-        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
-            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
-                                                                                                                            bucketName,
-                                                                                                                            catalogObjectName)) {
-                throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+            // Check Grants
+            if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+                AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+                if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
+                                                                                                                                bucketName,
+                                                                                                                                catalogObjectName)) {
+                    throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+                }
             }
         }
 
@@ -212,7 +211,7 @@ public class CatalogObjectGrantController {
                             @ApiResponse(code = 403, message = "Permission denied"), })
     @RequestMapping(method = GET)
     @ResponseStatus(HttpStatus.OK)
-    public List<CatalogObjectGrantMetadata> getAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket(
+    public List<CatalogObjectGrantMetadata> getAllCreatedCatalogObjectGrantsByTheCurrentUserForTheCurrentUserBucket(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName,
             @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser)

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantController.java
@@ -90,8 +90,8 @@ public class CatalogObjectGrantController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
-                                                                                                                           bucketName,
-                                                                                                                           catalogObjectName)) {
+                                                                                                                            bucketName,
+                                                                                                                            catalogObjectName)) {
                 throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
             }
         }
@@ -130,8 +130,8 @@ public class CatalogObjectGrantController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
-                                                                                                                           bucketName,
-                                                                                                                           catalogObjectName)) {
+                                                                                                                            bucketName,
+                                                                                                                            catalogObjectName)) {
                 throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
             }
         }
@@ -165,8 +165,8 @@ public class CatalogObjectGrantController {
         if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
-                                                                                                                           bucketName,
-                                                                                                                           catalogObjectName)) {
+                                                                                                                            bucketName,
+                                                                                                                            catalogObjectName)) {
                 throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
             }
         }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantController.java
@@ -29,7 +29,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.*;
 
 import java.util.List;
 
-import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetaData;
+import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetadata;
 import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
 import org.ow2.proactive.catalog.service.RestApiAccessService;
 import org.ow2.proactive.catalog.service.exception.AccessDeniedException;
@@ -70,7 +70,7 @@ public class CatalogObjectGrantController {
                             @ApiResponse(code = 403, message = "Permission denied"), })
     @RequestMapping(value = REQUEST_API_QUERY, method = POST)
     @ResponseStatus(HttpStatus.CREATED)
-    public CatalogObjectGrantMetaData createCatalogObjectGrant(
+    public CatalogObjectGrantMetadata createCatalogObjectGrant(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName, @PathVariable String catalogObjectName,
             @ApiParam(value = "The user who is creating this grant") @RequestParam(value = "currentUser", required = true) String currentUser,
@@ -111,7 +111,7 @@ public class CatalogObjectGrantController {
                             @ApiResponse(code = 403, message = "Permission denied"), })
     @RequestMapping(value = REQUEST_API_QUERY, method = DELETE)
     @ResponseStatus(HttpStatus.OK)
-    public CatalogObjectGrantMetaData deleteCatalogObjectGrant(
+    public CatalogObjectGrantMetadata deleteCatalogObjectGrant(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName, @PathVariable String catalogObjectName,
             @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
@@ -145,7 +145,7 @@ public class CatalogObjectGrantController {
                             @ApiResponse(code = 403, message = "Permission denied"), })
     @RequestMapping(value = REQUEST_API_QUERY, method = PUT)
     @ResponseStatus(HttpStatus.OK)
-    private CatalogObjectGrantMetaData updateCatalogObjectGrant(
+    private CatalogObjectGrantMetadata updateCatalogObjectGrant(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName, @PathVariable String catalogObjectName,
             @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
@@ -185,7 +185,7 @@ public class CatalogObjectGrantController {
                             @ApiResponse(code = 403, message = "Permission denied"), })
     @RequestMapping(value = REQUEST_API_QUERY, method = GET)
     @ResponseStatus(HttpStatus.OK)
-    public List<CatalogObjectGrantMetaData> getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(
+    public List<CatalogObjectGrantMetadata> getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName, @PathVariable String catalogObjectName,
             @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
@@ -212,7 +212,7 @@ public class CatalogObjectGrantController {
                             @ApiResponse(code = 403, message = "Permission denied"), })
     @RequestMapping(method = GET)
     @ResponseStatus(HttpStatus.OK)
-    public List<CatalogObjectGrantMetaData> getAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket(
+    public List<CatalogObjectGrantMetadata> getAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket(
             @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
             @PathVariable String bucketName,
             @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser)

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantController.java
@@ -1,0 +1,232 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.rest.controller;
+
+import static org.springframework.web.bind.annotation.RequestMethod.*;
+
+import java.util.List;
+
+import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetaData;
+import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
+import org.ow2.proactive.catalog.service.RestApiAccessService;
+import org.ow2.proactive.catalog.service.exception.AccessDeniedException;
+import org.ow2.proactive.catalog.service.exception.CatalogObjectGrantAccessException;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+import org.ow2.proactive.microservices.common.exception.NotAuthenticatedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.extern.log4j.Log4j2;
+
+
+@Log4j2
+@RestController
+@RequestMapping(value = "/buckets/{bucketName}/grant")
+public class CatalogObjectGrantController {
+
+    private static final String REQUEST_API_QUERY = "/resources/{catalogObjectName}/grant";
+
+    @Autowired
+    private CatalogObjectGrantService catalogObjectGrantService;
+
+    @Autowired
+    private RestApiAccessService restApiAccessService;
+
+    @Value("${pa.catalog.security.required.sessionid}")
+    private boolean sessionIdRequired;
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Create a new username grant or a user group grant access for a catalog object")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(value = REQUEST_API_QUERY, method = POST)
+    @ResponseStatus(HttpStatus.CREATED)
+    public CatalogObjectGrantMetaData createCatalogObjectGrant(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @PathVariable String bucketName, @PathVariable String catalogObjectName,
+            @ApiParam(value = "The user who is creating this grant") @RequestParam(value = "currentUser", required = true) String currentUser,
+            @ApiParam(value = "The access type of the grant") @RequestParam(value = "accessType", required = true) String accessType,
+            @ApiParam(value = "The name of the user that will have grant access", defaultValue = "") @RequestParam(value = "username", required = false, defaultValue = "") String username,
+            @ApiParam(value = "The name of the user group that will have grant access", defaultValue = "") @RequestParam(value = "userGroup", required = false, defaultValue = "") String userGroup)
+            throws NotAuthenticatedException, AccessDeniedException {
+
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        // Check Grants
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+            if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
+                                                                                                                           bucketName,
+                                                                                                                           catalogObjectName)) {
+                throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+            }
+        }
+
+        return catalogObjectGrantService.createCatalogObjectGrant(bucketName,
+                                                                  catalogObjectName,
+                                                                  currentUser,
+                                                                  accessType,
+                                                                  username,
+                                                                  userGroup);
+
+    }
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Delete a username grant or a user group grant access for a catalog object")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(value = REQUEST_API_QUERY, method = DELETE)
+    @ResponseStatus(HttpStatus.OK)
+    public CatalogObjectGrantMetaData deleteCatalogObjectGrant(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @PathVariable String bucketName, @PathVariable String catalogObjectName,
+            @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
+            @ApiParam(value = "The name of the user that will have grant access", defaultValue = "") @RequestParam(value = "username", required = false, defaultValue = "") String username,
+            @ApiParam(value = "The name of the user group that will have grant access", defaultValue = "") @RequestParam(value = "userGroup", required = false, defaultValue = "") String userGroup)
+            throws NotAuthenticatedException, AccessDeniedException {
+
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        // Check Grants
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+            if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
+                                                                                                                           bucketName,
+                                                                                                                           catalogObjectName)) {
+                throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+            }
+        }
+        return catalogObjectGrantService.deleteCatalogObjectGrant(bucketName, catalogObjectName, username, userGroup);
+
+    }
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Update a username grant or a user group grant access for a catalog object")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(value = REQUEST_API_QUERY, method = PUT)
+    @ResponseStatus(HttpStatus.OK)
+    private CatalogObjectGrantMetaData updateCatalogObjectGrant(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @PathVariable String bucketName, @PathVariable String catalogObjectName,
+            @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
+            @ApiParam(value = "The new access type") @RequestParam(value = "accessType", required = true) String accessType,
+            @ApiParam(value = "The name of the user that have the grant access", defaultValue = "") @RequestParam(value = "username", required = false, defaultValue = "") String username,
+            @ApiParam(value = "The name of the user group that have the grant access", defaultValue = "") @RequestParam(value = "userGroup", required = false, defaultValue = "") String userGroup)
+            throws NotAuthenticatedException, AccessDeniedException {
+
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        // Check Grants
+        if (!restApiAccessService.isBucketAccessibleByUser(sessionIdRequired, sessionId, bucketName)) {
+            AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
+            if (!catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(user,
+                                                                                                                           bucketName,
+                                                                                                                           catalogObjectName)) {
+                throw new CatalogObjectGrantAccessException(bucketName, catalogObjectName);
+            }
+        }
+
+        return catalogObjectGrantService.updateCatalogObjectGrant(username,
+                                                                  userGroup,
+                                                                  catalogObjectName,
+                                                                  bucketName,
+                                                                  accessType);
+
+    }
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Get all assigned grants for the user and his group on a specific catalog object")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(value = REQUEST_API_QUERY, method = GET)
+    @ResponseStatus(HttpStatus.OK)
+    public List<CatalogObjectGrantMetaData> getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @PathVariable String bucketName, @PathVariable String catalogObjectName,
+            @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser,
+            @ApiParam(value = "The current userGroup") @RequestParam(value = "userGroup", required = true) String userGroup)
+            throws NotAuthenticatedException, AccessDeniedException {
+
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        return catalogObjectGrantService.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(currentUser,
+                                                                                                       userGroup,
+                                                                                                       catalogObjectName,
+                                                                                                       bucketName);
+
+    }
+
+    @SuppressWarnings("DefaultAnnotationParam")
+    @ApiOperation(value = "Get all created grants by the current user on all bucket's object")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
+                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @RequestMapping(method = GET)
+    @ResponseStatus(HttpStatus.OK)
+    public List<CatalogObjectGrantMetaData> getAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket(
+            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @PathVariable String bucketName,
+            @ApiParam(value = "The current user") @RequestParam(value = "currentUser", required = true) String currentUser)
+            throws NotAuthenticatedException, AccessDeniedException {
+
+        if (sessionIdRequired) {
+            // Check session validation
+            if (!restApiAccessService.isUserSessionActive(sessionId, currentUser)) {
+                throw new AccessDeniedException("Session id is not active. Please login.");
+            }
+        }
+
+        return catalogObjectGrantService.getAllCreatedCatalogObjectGrantsForThisBucket(currentUser, bucketName);
+        //getAllCreatedCatalogObjectGrantsForTheCBucket
+    }
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/BucketGrantService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/BucketGrantService.java
@@ -1,0 +1,420 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service;
+
+import static org.ow2.proactive.catalog.util.AccessType.*;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.ow2.proactive.catalog.dto.BucketGrantMetadata;
+import org.ow2.proactive.catalog.dto.BucketMetadata;
+import org.ow2.proactive.catalog.repository.BucketGrantRepository;
+import org.ow2.proactive.catalog.repository.BucketRepository;
+import org.ow2.proactive.catalog.repository.entity.BucketEntity;
+import org.ow2.proactive.catalog.repository.entity.BucketGrantEntity;
+import org.ow2.proactive.catalog.service.exception.BucketGrantAlreadyExistsException;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.log4j.Log4j2;
+
+
+/**
+ * @author ActiveEon Team
+ */
+@Log4j2
+@Service
+@Transactional
+public class BucketGrantService {
+
+    @Autowired
+    private BucketRepository bucketRepository;
+
+    @Autowired
+    private BucketGrantRepository bucketGrantRepository;
+
+    @Autowired
+    private CatalogObjectGrantService catalogObjectGrantService;
+
+    @Autowired
+    private GrantAccessTypeHelperService grantAccessTypeHelperService;
+
+    /**
+     *
+     * Get the grants assigned to a user and his group
+     *
+     * @param username username
+     * @param userGroup user group
+     * @return all grants that are assigned to a specific username and his group
+     */
+    public List<BucketGrantMetadata> getAllAssignedGrantsForUserAndHisGroup(String username, String userGroup) {
+        // Get all user assigned grants from the db
+        List<BucketGrantEntity> dbUserBucketGrants = bucketGrantRepository.findAllGrantsAssignedToAUsername(username);
+        // Add the grants that are assigned to his group
+        List<BucketGrantEntity> dbGroupBucketGrants = bucketGrantRepository.findAllGrantsAssignedToAUserGroup(userGroup);
+
+        // Result list
+        List<BucketGrantEntity> result = new LinkedList<>();
+
+        // Check for duplicates grants in the group grant
+        // If the user group has a grant over a different bucket we add it to the result
+        // If not, we check the access type and compare them to add only the higher access grant
+        if (dbGroupBucketGrants != null) {
+            for (BucketGrantEntity groupBucketGrant : dbGroupBucketGrants) {
+                for (BucketGrantEntity userBucketGrant : dbUserBucketGrants) {
+                    // Grant over different buckets
+                    if (!groupBucketGrant.getBucketEntity().getId().equals(userBucketGrant.getBucketEntity().getId())) {
+                        result.add(userBucketGrant);
+                        result.add(groupBucketGrant);
+                    } else if (!groupBucketGrant.getAccessType().equals(userBucketGrant.getAccessType())) {
+                        // Grant over the same bucket but with different access type
+                        String userGrantAccessType = userBucketGrant.getAccessType();
+                        String userGroupGrantAccessType = groupBucketGrant.getAccessType();
+                        // Compare the access type and add the higher one
+                        if (getPriorityLevel(userGrantAccessType, userGroupGrantAccessType) == 2) {
+                            result.add(groupBucketGrant);
+                        } else {
+                            result.add(userBucketGrant);
+                        }
+                    }
+                }
+            }
+        } else if(dbUserBucketGrants != null) {
+            result.addAll(dbUserBucketGrants);
+        }
+        if(!result.isEmpty()) {
+            return result.stream().map(BucketGrantMetadata::new).collect(Collectors.toList());
+        } else {
+            return new LinkedList<>();
+        }
+    }
+
+    /**
+     *
+     * @param firstAccessType first access type
+     * @param secondAccessType second access type
+     * @return 1 if the first access type is higher than the second and 2 in opposite case
+     */
+    private int getPriorityLevel(String firstAccessType, String secondAccessType) {
+        int priority = 1;
+        switch (firstAccessType) {
+            case READ_ACCESS_TYPE:
+                if (secondAccessType.equals(ADMIN_ACCESS_TYPE) || secondAccessType.equals(WRITE_ACCESS_TYPE)) {
+                    priority = 2;
+                }
+            case WRITE_ACCESS_TYPE:
+                if (secondAccessType.equals(ADMIN_ACCESS_TYPE)) {
+                    priority = 2;
+                }
+        }
+        return priority;
+    }
+
+    /**
+     *
+     * Update the access type for an existing user grant
+     *
+     * @param bucketName bucket name
+     * @param username username
+     * @param accessType new access type
+     * @return the updated grant assigned to the user and for the specific bucket
+     */
+    public BucketGrantMetadata updateBucketGrantForASpecificUser(String bucketName, String username,
+            String accessType) {
+
+        // Find the bucket and get its id
+        long bucketId;
+        BucketEntity bucketEntity = bucketRepository.findOneByBucketName(bucketName);
+
+        if(bucketEntity !=null) {
+            bucketId = bucketEntity.getId();
+
+            // Find the bucket grant assigned to the current user
+            BucketGrantEntity bucketGrantEntity = bucketGrantRepository.findBucketGrantByUsername(bucketId, username);
+
+            if(bucketGrantEntity !=null) {
+                // Update the access type
+                bucketGrantEntity.setAccessType(accessType);
+
+                // Save the grant
+                bucketGrantEntity = bucketGrantRepository.save(bucketGrantEntity);
+
+                return new BucketGrantMetadata(bucketGrantEntity);
+
+            }
+        }
+        return null;
+    }
+
+    /**
+     *
+     * Update the access type for an existing user group grant
+     *
+     * @param bucketName bucket name
+     * @param userGroup user group
+     * @param accessType new access type
+     * @return the updated grant assigned to the user group and the specific bucket name
+     */
+    public BucketGrantMetadata updateBucketGrantForASpecificUserGroup(String bucketName, String userGroup,
+            String accessType) {
+
+        // Find the bucket and get its id
+        long bucketId;
+        BucketEntity bucketEntity = bucketRepository.findOneByBucketName(bucketName);
+        if(bucketEntity !=null) {
+            bucketId = bucketEntity.getId();
+
+            // Find the bucket grant assigned to the current user group
+            BucketGrantEntity bucketGrantEntity = bucketGrantRepository.findBucketGrantByUserGroup(bucketId, userGroup);
+
+            if (bucketGrantEntity != null) {
+                // Update the access type
+                bucketGrantEntity.setAccessType(accessType);
+            } else {
+                throw new DataIntegrityViolationException("Bucket grant was not found in the DB");
+            }
+
+            // Save the modifications
+            bucketGrantEntity = bucketGrantRepository.save(bucketGrantEntity);
+
+            return new BucketGrantMetadata(bucketGrantEntity);
+        }
+        return null;
+    }
+
+    /**
+     *
+     * @param username username
+     * @return all grants created by the current user
+     */
+    public List<BucketGrantMetadata> getAllGrantsCreatedByUsername(String username) {
+        // Get from the db all grants that are created by the current user
+        List<BucketGrantEntity> dbUserCreatedGrants = bucketGrantRepository.findAllGrantsCreatedByUsername(username);
+
+        // Transform the result to BucketGrantMetadata and return it
+        if(dbUserCreatedGrants != null) {
+            return dbUserCreatedGrants.stream().map(BucketGrantMetadata::new).collect(Collectors.toList());
+        } else {
+            return new LinkedList<>();
+        }
+    }
+
+    /**
+     *
+     *
+     * @param bucketName bucket name
+     * @param currentUser user with admin rights on the current bucket
+     * @param accessType grant access type
+     * @param username targeted username
+     * @param groupName targeted group name
+     * @return a newly created bucket grant assigned to a user or a user group
+     * @throws DataIntegrityViolationException in case of duplicate grant or internal db errors
+     */
+    public BucketGrantMetadata createBucketGrant(String bucketName, String currentUser, String accessType,
+            String username, String groupName) throws DataIntegrityViolationException {
+        // Find the corresponding bucket from the DB
+        BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
+        // Throw an error if the bucket was not found
+        if (bucket == null) {
+            throw new DataIntegrityViolationException("Bucket: " + bucketName + " does not exist in the catalog");
+        }
+
+        BucketGrantEntity bucketGrantEntity = null;
+        if (!username.equals("") && groupName.equals("")) {
+            // Case if the grant targets a specific user
+            // Check if a similar grant is available in the DB
+            BucketGrantEntity dbUsernameBucketGrant = bucketGrantRepository.findBucketGrantByUsername(bucket.getId(),
+                                                                                                      username);
+            // Throw an exception if similar grant exists
+            if (dbUsernameBucketGrant != null && dbUsernameBucketGrant.getProfiteer().equals(username) &&
+                dbUsernameBucketGrant.getBucketEntity().getId().equals(bucket.getId()) &&
+                dbUsernameBucketGrant.getAccessType().equals(accessType)) {
+                throw new BucketGrantAlreadyExistsException(bucketName, username);
+            }
+            // BucketGrant attributes: Type, Profiteer, Access Type and the Bucket
+            bucketGrantEntity = new BucketGrantEntity("user", currentUser, username, accessType, bucket);
+        } else if (username.equals("") && !groupName.equals("")) {
+            // Case if the grant targets a specific group
+            // Check if a similar grant is available in the DB
+            BucketGrantEntity dbUserGroupBucketGrant = bucketGrantRepository.findBucketGrantByUserGroup(bucket.getId(),
+                                                                                                        groupName);
+            // Throw an exception if similar grant exists
+            if (dbUserGroupBucketGrant != null && dbUserGroupBucketGrant.getProfiteer().equals(groupName) &&
+                dbUserGroupBucketGrant.getBucketEntity().getId().equals(bucket.getId()) &&
+                dbUserGroupBucketGrant.getAccessType().equals(accessType)) {
+                throw new BucketGrantAlreadyExistsException(bucketName, groupName);
+            }
+            // BucketGrant attributes: Type, Profiteer, Access Type and the Bucket
+            bucketGrantEntity = new BucketGrantEntity("group", currentUser, groupName, accessType, bucket);
+        }
+
+        // Save the grant in db
+        bucketGrantEntity = bucketGrantRepository.save(bucketGrantEntity);
+
+        return new BucketGrantMetadata(bucketGrantEntity);
+    }
+
+    /**
+     *
+     * @param bucketName bucket name
+     * @param username username
+     * @param userGroup user group
+     * @return a response indicating the status of deletion of an existing grant
+     */
+    public BucketGrantMetadata deleteBucketGrant(String bucketName, String username, String userGroup) {
+        // Find the bucket
+        BucketEntity bucketEntity = bucketRepository.findOneByBucketName(bucketName);
+        BucketGrantEntity bucketGrantEntity = null;
+        if (!username.equals("") && userGroup.equals("")) {
+            // Case if the grant targets a specific user
+            // Find the Grant for the current user
+            bucketGrantEntity = bucketGrantRepository.findBucketGrantByUsername(bucketEntity.getId(), username);
+        } else if (username.equals("") && !userGroup.equals("")) {
+            // Case if the grant targets a specific group
+            // Find the Grant fot the current userGroup
+            bucketGrantEntity = bucketGrantRepository.findBucketGrantByUserGroup(bucketEntity.getId(), userGroup);
+        }
+
+        if (bucketGrantEntity != null) {// Delete the grant from DB
+            bucketGrantRepository.delete(bucketGrantEntity);
+        } else {
+            throw new DataIntegrityViolationException("Bucket grant was not found in the DB.");
+        }
+
+        return new BucketGrantMetadata(bucketGrantEntity);
+    }
+
+    /**
+     *
+     * This function checks for admin grant over a bucket for the current user
+     *
+     * @param user username
+     * @param bucketName bucket name
+     * @return true if the user has grant admin rights over the bucket and false otherwise
+     */
+    public boolean isTheUserGrantSufficientForTheCurrentTask(AuthenticatedUser user,
+                                                             String bucketName, String requiredAccessType) {
+        // Find the bucket and get its id
+        long bucketId = bucketRepository.findOneByBucketName(bucketName).getId();
+
+        List<BucketGrantEntity> grants = bucketGrantRepository.findAllGrantsByBucket(bucketId);
+
+        grants.removeIf(bucketGrantEntity -> ((!bucketGrantEntity.getProfiteer().equals(user.getName()) &&
+                                               bucketGrantEntity.getGrantee().equals("user")) ||
+                                              (!user.getGroups().contains(bucketGrantEntity.getProfiteer()) &&
+                                               bucketGrantEntity.getGrantee().equals("group"))));
+
+        BucketGrantEntity bucketGrantEntity;
+
+        // We need to pick only the grant with the higher access type
+        if (grants.size() > 0) {
+            bucketGrantEntity = grants.get(0);
+            if (!bucketGrantEntity.getAccessType().equals(ADMIN_ACCESS_TYPE)) {
+                for (int index = 1; index < grants.size(); index++) {
+                    if (getPriorityLevel(bucketGrantEntity.getAccessType(), grants.get(index).getAccessType()) == 2) {
+                        bucketGrantEntity = grants.get(index);
+                    }
+                }
+            } else {
+                // The bucketGrantEntity object has an admin grant type - no need to de complementary checks
+                return true;
+            }
+        } else {
+            return false;
+        }
+
+        return grantAccessTypeHelperService.compareGrantAccessType(bucketGrantEntity.getAccessType(),
+                                                                   requiredAccessType);
+
+    }
+
+    /**
+     *
+     * @param user authenticated used
+     * @return the list of buckets that the user has grant access over them
+     */
+    public List<BucketMetadata> getBucketsForUserByGrants(AuthenticatedUser user) {
+        // Buckets list to return
+        Set<BucketEntity> buckets = new HashSet<>();
+
+        // Bucket grants metadata list
+        List<BucketGrantMetadata> bucketGrants = new LinkedList<>();
+
+        // Get the list of bucket ids from all objet grant
+        Set<Long> bucketsIds = new HashSet<>(catalogObjectGrantService.getAllBucketIdsFromGrantsAssignedToUsername(user.getName()));
+
+        // Get bucket grants from DB and add them to the bucket grant list
+        // Get distinct buckets' ids from catalog object grants and add them to the corresponding list
+        for (String group : user.getGroups()) {
+            bucketGrants.addAll(this.getAllAssignedGrantsForUserAndHisGroup(user.getName(), group));
+            bucketsIds.addAll(catalogObjectGrantService.getAllBucketIdsFromGrantsAssignedToUserGroup(group));
+        }
+
+        // Get from bucket grants the targeted buckets
+        for (BucketGrantMetadata bucketGrantMetadata : bucketGrants) {
+            buckets.add(bucketRepository.findOne(bucketGrantMetadata.getBucketId()));
+        }
+
+        // Get the buckets from the list of buckets' ids
+        for (Long id : bucketsIds) {
+            buckets.add(bucketRepository.findOne(id));
+        }
+
+        // Return the result
+        // TODO check why the sizes of all buckets that have grants are sometime mixing up
+        return buckets.stream()
+                      .map(bucketEntity -> new BucketMetadata(bucketEntity, bucketEntity.getCatalogObjects().size()))
+                      .collect(Collectors.toList());
+    }
+
+    /**
+     *
+     * This function delete all bucket grants when the bucket is deleted. It will delete also all bucket
+     * objects grants if they were found.
+     *
+     * @param bucketId the deleted bucket name
+     *
+     */
+    public void deleteAllBucketGrants(long bucketId) {
+        // Get existing grants
+        List<BucketGrantEntity> existingBucketGrantsToDelete = bucketGrantRepository.findAllGrantsByBucket(bucketId);
+
+        if (existingBucketGrantsToDelete != null) {
+            // Delete all bucket Grants
+            bucketGrantRepository.delete(existingBucketGrantsToDelete);
+
+            //Delete all catalog objects grants found in this bucket
+            catalogObjectGrantService.deleteAllCatalogObjectsGrantsAssignedToABucket(bucketId);
+        }
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
@@ -243,11 +243,11 @@ public class BucketService {
         // Get the bucketId
         long bucketId = bucketEntity.getId();
 
-        // Delete the bucket
-        bucketRepository.delete(bucketId);
-
         // Delete all bucket grants
         bucketGrantService.deleteAllBucketGrants(bucketId);
+
+        // Delete the bucket
+        bucketRepository.delete(bucketId);
 
         return new BucketMetadata(bucketEntity);
     }

--- a/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
@@ -73,6 +73,9 @@ public class BucketService {
     private OwnerGroupStringHelper ownerGroupStringHelper;
 
     @Autowired
+    private BucketGrantService bucketGrantService;
+
+    @Autowired
     CatalogObjectService catalogObjectService;
 
     public BucketMetadata createBucket(String name) {
@@ -237,7 +240,15 @@ public class BucketService {
         if (!bucketEntity.getCatalogObjects().isEmpty()) {
             throw new DeleteNonEmptyBucketException(bucketName);
         }
-        bucketRepository.delete(bucketEntity.getId());
+        // Get the bucketId
+        long bucketId = bucketEntity.getId();
+
+        // Delete the bucket
+        bucketRepository.delete(bucketId);
+
+        // Delete all bucket grants
+        bucketGrantService.deleteAllBucketGrants(bucketId);
+
         return new BucketMetadata(bucketEntity);
     }
 

--- a/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/BucketService.java
@@ -206,8 +206,8 @@ public class BucketService {
             List<Object[]> bucketsFromDB;
             if (contentType.isPresent() || objectName.isPresent()) {
                 bucketsFromDB = bucketRepository.findBucketContainingKindListAndContentTypeAndObjectName(kindList,
-                                                                                                         contentType.orElse(""),
-                                                                                                         objectName.orElse(""));
+                                                                                                         contentType.orElse(null),
+                                                                                                         objectName.orElse(null));
             } else { // only kind.isPresent()
                 bucketsFromDB = bucketRepository.findBucketContainingKindList(kindList);
             }

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
@@ -89,7 +89,7 @@ public class CatalogObjectGrantService {
 
         BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
 
-        checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
+        throwExceptionIfCatalogObjectIsNull(catalogObjectRevisionEntity, bucketName, catalogObjectName);
 
         if (!username.isEmpty() && groupName.isEmpty()) {
             // Case if the grant targets a specific user
@@ -153,7 +153,7 @@ public class CatalogObjectGrantService {
         CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
                                                                                                                                          catalogObjectName);
 
-        checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
+        throwExceptionIfCatalogObjectIsNull(catalogObjectRevisionEntity, bucketName, catalogObjectName);
 
         BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
 
@@ -200,7 +200,7 @@ public class CatalogObjectGrantService {
         CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
                                                                                                                                          catalogObjectName);
 
-        checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
+        throwExceptionIfCatalogObjectIsNull(catalogObjectRevisionEntity, bucketName, catalogObjectName);
 
         BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
 
@@ -246,7 +246,7 @@ public class CatalogObjectGrantService {
         CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
                                                                                                                                          catalogObjectName);
 
-        checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
+        throwExceptionIfCatalogObjectIsNull(catalogObjectRevisionEntity, bucketName, catalogObjectName);
 
         // Find the bucket
         BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
@@ -314,8 +314,8 @@ public class CatalogObjectGrantService {
      * @param bucketName bucket name
      * @param catalogObjectName WF name
      */
-    private void checkForAvailability(CatalogObjectRevisionEntity catalogObjectRevisionEntity, String bucketName,
-            String catalogObjectName) {
+    private void throwExceptionIfCatalogObjectIsNull(CatalogObjectRevisionEntity catalogObjectRevisionEntity,
+            String bucketName, String catalogObjectName) {
         if (catalogObjectRevisionEntity == null) {
             throw new DataIntegrityViolationException("Catalog object:" + catalogObjectName +
                                                       " does not exist in bucket: " + bucketName);

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
@@ -1,0 +1,570 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service;
+
+import static org.ow2.proactive.catalog.util.AccessType.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetaData;
+import org.ow2.proactive.catalog.repository.BucketRepository;
+import org.ow2.proactive.catalog.repository.CatalogObjectGrantRepository;
+import org.ow2.proactive.catalog.repository.CatalogObjectRevisionRepository;
+import org.ow2.proactive.catalog.repository.entity.*;
+import org.ow2.proactive.catalog.service.exception.CatalogObjectGrantAlreadyExistsException;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+import org.ow2.proactive.catalog.util.AccessType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.log4j.Log4j2;
+
+
+/**
+ * @author ActiveEon Team
+ */
+@Log4j2
+@Component
+@Transactional
+public class CatalogObjectGrantService {
+
+    @Autowired
+    private CatalogObjectGrantRepository catalogObjectGrantRepository;
+
+    @Autowired
+    private BucketRepository bucketRepository;
+
+    @Autowired
+    private CatalogObjectRevisionRepository catalogObjectRevisionRepository;
+
+    @Autowired
+    private GrantAccessTypeHelperService grantAccessTypeHelperService;
+
+    /**
+     *
+     * @param bucketName bucket name
+     * @param catalogObjectName WF name
+     * @param currentUser current user with admin rights over the bucket
+     * @param accessType access type
+     * @param username username
+     * @param groupName user group
+     * @return a new grant access for the specific WF
+     * @throws DataIntegrityViolationException in case of an internal db query error
+     */
+    public CatalogObjectGrantMetaData createCatalogObjectGrant(String bucketName, String catalogObjectName,
+            String currentUser, String accessType, String username, String groupName)
+            throws DataIntegrityViolationException {
+
+        CatalogObjectGrantEntity catalogObjectGrantEntity = null;
+
+        List<String> bucketsName = new LinkedList<>();
+        bucketsName.add(bucketName);
+        CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
+                                                                                                                                         catalogObjectName);
+
+        BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
+
+        checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
+
+        if (!username.equals("") && groupName.equals("")) {
+            // Case if the grant targets a specific user
+            CatalogObjectGrantEntity dbCatalogObjectGrantEntityForUser = catalogObjectGrantRepository.findCatalogObjectGrantByUsername(catalogObjectRevisionEntity.getId(),
+                                                                                                                                       username,
+                                                                                                                                       bucket.getId());
+            if (dbCatalogObjectGrantEntityForUser != null &&
+                (dbCatalogObjectGrantEntityForUser.getProfiteer().equals(username) &&
+                 dbCatalogObjectGrantEntityForUser.getCatalogObjectRevisionEntity()
+                                                  .getId()
+                                                  .equals(catalogObjectRevisionEntity.getId()) &&
+                 dbCatalogObjectGrantEntityForUser.getAccessType().equals(accessType))) {
+                throw new CatalogObjectGrantAlreadyExistsException(catalogObjectName, bucketName, username);
+            }
+            catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                    currentUser,
+                                                                    username,
+                                                                    accessType,
+                                                                    catalogObjectRevisionEntity,
+                                                                    bucket);
+
+        } else if (username.equals("") && !groupName.equals("")) {
+            // Case if the grant targets a specific user group
+            CatalogObjectGrantEntity dbCatalogObjectGrantEntityForUserGroup = catalogObjectGrantRepository.findCatalogObjectGrantByUserGroup(catalogObjectRevisionEntity.getId(),
+                                                                                                                                             groupName,
+                                                                                                                                             bucket.getId());
+            if (dbCatalogObjectGrantEntityForUserGroup != null &&
+                dbCatalogObjectGrantEntityForUserGroup.getProfiteer().equals(username) &&
+                dbCatalogObjectGrantEntityForUserGroup.getCatalogObjectRevisionEntity()
+                                                      .getId()
+                                                      .equals(catalogObjectRevisionEntity.getId()) &&
+                dbCatalogObjectGrantEntityForUserGroup.getAccessType().equals(accessType)) {
+                throw new CatalogObjectGrantAlreadyExistsException(catalogObjectName, bucketName, groupName);
+            }
+            // BucketGrant attributes: Type, Profiteer, Access Type and the Bucket
+            catalogObjectGrantEntity = new CatalogObjectGrantEntity("group",
+                    currentUser,
+                                                                    groupName,
+                                                                    accessType,
+                                                                    catalogObjectRevisionEntity,
+                                                                    bucket);
+        }
+        catalogObjectGrantEntity = catalogObjectGrantRepository.save(catalogObjectGrantEntity);
+
+        return new CatalogObjectGrantMetaData(catalogObjectGrantEntity);
+    }
+
+    /**
+     * Delete an existing user or user group grant
+     * @param bucketName bucket name
+     * @param catalogObjectName WF name
+     * @param username username
+     * @param groupName user group
+     * @return an empty catalog grant metadata if the deletion process was successful
+     */
+    public CatalogObjectGrantMetaData deleteCatalogObjectGrant(String bucketName, String catalogObjectName,
+            String username, String groupName) {
+
+        List<String> bucketsName = new LinkedList<>();
+        bucketsName.add(bucketName);
+        CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
+                                                                                                                                         catalogObjectName);
+
+        checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
+
+        BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
+
+        CatalogObjectGrantEntity catalogObjectGrantEntity = null;
+
+        assert bucket != null;
+        if (!username.equals("") && groupName.equals("")) {
+            // Case if the grant targets a specific user
+            catalogObjectGrantEntity = catalogObjectGrantRepository.findCatalogObjectGrantByUsername(catalogObjectRevisionEntity.getId(),
+                                                                                                     username,
+                                                                                                     bucket.getId());
+        } else if (username.equals("") && !groupName.equals("")) {
+            catalogObjectGrantEntity = catalogObjectGrantRepository.findCatalogObjectGrantByUserGroup(catalogObjectRevisionEntity.getId(),
+                                                                                                      groupName,
+                                                                                                      bucket.getId());
+        }
+
+        if (catalogObjectGrantEntity != null) {
+            catalogObjectGrantRepository.delete(catalogObjectGrantEntity);
+        } else {
+            throw new DataIntegrityViolationException("Catalog object grant was not found in the DB.");
+        }
+
+        return new CatalogObjectGrantMetaData(catalogObjectGrantEntity);
+
+    }
+
+    /**
+     *
+     * Set a new access type for an available grant
+     *
+     * @param username username
+     * @param groupName user group
+     * @param catalogObjectName WF name
+     * @param bucketName bucket name
+     * @param accessType new grant access type
+     * @return the updated grant
+     */
+    public CatalogObjectGrantMetaData updateCatalogObjectGrant(String username, String groupName,
+            String catalogObjectName, String bucketName, String accessType) {
+
+        List<String> bucketsName = new LinkedList<>();
+        bucketsName.add(bucketName);
+        CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
+                                                                                                                                         catalogObjectName);
+
+        checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
+
+        BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
+
+        CatalogObjectGrantEntity catalogObjectGrantEntity = null;
+
+        if (!username.equals("") && groupName.equals("")) {
+            // Case if the grant targets a specific user
+            catalogObjectGrantEntity = catalogObjectGrantRepository.findCatalogObjectGrantByUsername(catalogObjectRevisionEntity.getId(),
+                                                                                                     username,
+                                                                                                     bucket.getId());
+        } else if (username.equals("") && !groupName.equals("")) {
+            // Case if the grant targets a specific user group
+            catalogObjectGrantEntity = catalogObjectGrantRepository.findCatalogObjectGrantByUserGroup(catalogObjectRevisionEntity.getId(),
+                                                                                                      groupName,
+                                                                                                      bucket.getId());
+        }
+
+        if (catalogObjectGrantEntity != null) {
+            catalogObjectGrantEntity.setAccessType(accessType);
+        } else {
+            throw new DataIntegrityViolationException("Catalog object grant was not found in the DB");
+        }
+
+        catalogObjectGrantEntity = catalogObjectGrantRepository.save(catalogObjectGrantEntity);
+
+        return new CatalogObjectGrantMetaData(catalogObjectGrantEntity);
+    }
+
+    /**
+     *
+     * @param username username
+     * @param userGroup user group
+     * @param catalogObjectName WF name
+     * @param bucketName bucket name
+     * @return the list of all catalog objects grants assigned to a user and his group
+     */
+    public List<CatalogObjectGrantMetaData> getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(
+            String username, String userGroup, String catalogObjectName, String bucketName) {
+
+        // Find the catalog object
+        List<String> bucketsName = new LinkedList<>();
+        bucketsName.add(bucketName);
+        CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
+                                                                                                                                         catalogObjectName);
+
+        checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
+
+        // Find the bucket
+        BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
+
+        // Get all user catalog object grants from DB
+        List<CatalogObjectGrantEntity> dbUserCatalogObjectGrants = catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUsername(username,
+                                                                                                                                              catalogObjectRevisionEntity.getId(),
+                                                                                                                                              bucket.getId());
+
+        // Get all user group catalog objects grants from DB
+        List<CatalogObjectGrantEntity> dbGroupCatalogObjectGrants = catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUserGroup(userGroup,
+                                                                                                                                                catalogObjectRevisionEntity.getId(),
+                                                                                                                                                bucket.getId());
+
+        // Result list to return
+        List<CatalogObjectGrantEntity> result = new LinkedList<>();
+
+        // Check for duplicates grants in the group grant
+        // We check the access type and compare them to add only the higher access grant
+        if (!dbGroupCatalogObjectGrants.isEmpty()) {
+            for (CatalogObjectGrantEntity groupObjectGrant : dbGroupCatalogObjectGrants) {
+                for (CatalogObjectGrantEntity userObjectGrant : dbUserCatalogObjectGrants) {
+                    if (!groupObjectGrant.getAccessType().equals(userObjectGrant.getAccessType())) {
+                        // Get the access types of the user and the group grants
+                        String userGrantAccessType = userObjectGrant.getAccessType();
+                        String userGroupGrantAccessType = groupObjectGrant.getAccessType();
+                        // Compare the access type and add the higher one
+                        // If priority level equals 2 ==> Group grant is higher than the user
+                        if (getPriorityLevel(userGrantAccessType, userGroupGrantAccessType) == 2) {
+                            // Add the group grant
+                            result.add(groupObjectGrant);
+                        } else {
+                            // Add the user catalog object grant
+                            result.add(userObjectGrant);
+                        }
+                    } else {
+                        result.add(userObjectGrant);
+                    }
+                }
+            }
+        } else {
+            result.addAll(dbUserCatalogObjectGrants);
+        }
+        return result.stream().map(CatalogObjectGrantMetaData::new).collect(Collectors.toList());
+    }
+
+    /**
+     *
+     * @param accessType1 first access type
+     * @param accessType2 second access type
+     * @return 1 if the first access type is higher than the second and 2 in opposite case
+     */
+    private int getPriorityLevel(String accessType1, String accessType2) {
+        int priority = 1;
+        switch (accessType1) {
+            case READ_ACCESS_TYPE:
+                if (accessType2.equals(ADMIN_ACCESS_TYPE) || accessType2.equals(WRITE_ACCESS_TYPE)) {
+                    priority = 2;
+                }
+            case WRITE_ACCESS_TYPE:
+                if (accessType2.equals(ADMIN_ACCESS_TYPE)) {
+                    priority = 2;
+                }
+        }
+        return priority;
+    }
+
+    public List<CatalogObjectGrantMetaData> getAllCreatedCatalogObjectGrantsForThisBucket(String username,
+            String bucketName) {
+        BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
+        List<CatalogObjectGrantEntity> dbUserCreatedCatalogObjectGrants = catalogObjectGrantRepository.findAllCatalogObjectsGrantsCreatedByUsernameInASpecificBucket(username,
+                                                                                                                                                                     bucket.getId());
+        return dbUserCreatedCatalogObjectGrants.stream()
+                                               .map(CatalogObjectGrantMetaData::new)
+                                               .collect(Collectors.toList());
+    }
+
+    /**
+     * Check if a WF is available in a specific bucket
+     * @param catalogObjectRevisionEntity catalog entity
+     * @param bucketName bucket name
+     * @param catalogObjectName WF name
+     */
+    private void checkForAvailability(CatalogObjectRevisionEntity catalogObjectRevisionEntity, String bucketName,
+            String catalogObjectName) {
+        if (catalogObjectRevisionEntity == null) {
+            throw new DataIntegrityViolationException("Catalog object:" + catalogObjectName +
+                                                      " does not exist in bucket: " + bucketName);
+        }
+    }
+
+    /**
+     *
+     * Check if the user has admin grant rights over a catalog object
+     *
+     * @param user authenticated user
+     * @param bucketName name of the bucket
+     * @param catalogObjectName name of the catalog object
+     * @return true if the user has admin grant rights over the catalog object
+     */
+    public boolean checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(
+            AuthenticatedUser user, String bucketName, String catalogObjectName) {
+
+        // Find the bucket and get its id
+        long bucketId = bucketRepository.findOneByBucketName(bucketName).getId();
+
+        // Find the catalog object id
+        List<String> bucketsName = new LinkedList<>();
+        bucketsName.add(bucketName);
+        CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
+                                                                                                                                         catalogObjectName);
+
+        long catalogObjectId = catalogObjectRevisionEntity.getId();
+
+        // Find the user assigned grant for this bucket
+        List<CatalogObjectGrantEntity> dbUserCatalogObjectGrants = catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUsername(user.getName(),
+                                                                                                                                              catalogObjectId,
+                                                                                                                                              bucketId);
+
+        // Find the user group grants assigned to this catalogObject
+        List<CatalogObjectGrantEntity> grants = new LinkedList<>();
+        for (String group : user.getGroups()) {
+            List<CatalogObjectGrantEntity> groupGrants = catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUserGroup(group,
+                                                                                                                                     catalogObjectId,
+                                                                                                                                     bucketId);
+            if (!groupGrants.isEmpty()) {
+                grants.addAll(groupGrants);
+            }
+        }
+
+        grants.addAll(dbUserCatalogObjectGrants);
+
+        for (CatalogObjectGrantEntity grant : grants) {
+            if (grant.getAccessType().equals(ADMIN_ACCESS_TYPE)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     *
+     * Get buckets' id from user assigned grants
+     *
+     * @param username username
+     * @return the list of bucketIds found in all grants assigned to a user
+     */
+    public List<Long> getAllBucketIdsFromGrantsAssignedToUsername(String username) {
+        return catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUsername(username);
+    }
+
+    /**
+     *
+     * Get buckets' id from grants assigned to user group
+     *
+     * @param userGroup user group
+     * @return the list of bucketIds found in all grants assigned to a user group
+     */
+    public List<Long> getAllBucketIdsFromGrantsAssignedToUserGroup(String userGroup) {
+        return catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(userGroup);
+    }
+
+    /**
+     *
+     * Check if the user has grants over a bucket
+     *
+     * @param user authenticated user
+     * @param bucketName name of the bucket
+     * @return return true if the user has grants rights over a bucket
+     */
+    public boolean checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(AuthenticatedUser user,
+            String bucketName) {
+        // Find the bucket and get its id
+        long bucketId = bucketRepository.findOneByBucketName(bucketName).getId();
+
+        Set<Long> buckets = new HashSet<>(catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUsername(user.getName()));
+        for (String group : user.getGroups()) {
+            buckets.addAll(catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(group));
+        }
+
+        return buckets.contains(bucketId);
+
+    }
+
+    /**
+     *
+     * Get all grants metadata assigned to a specific bucket
+     *
+     * @param bucketName name of the bucket
+     * @return the list of all catalog object grant metadata assigned to a bucket
+     */
+    public List<CatalogObjectGrantMetaData> findAllCatalogObjectGrantsAssignedToABucket(String bucketName) {
+        return catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToABucket(bucketRepository.findOneByBucketName(bucketName)
+                                                                                                        .getId())
+                                           .stream()
+                                           .map(CatalogObjectGrantMetaData::new)
+                                           .collect(Collectors.toList());
+    }
+
+    /**
+     *
+     * Get the catalog object name from a catalog object grant
+     *
+     * @param grant catalog object grant
+     * @return the name of the catalog object
+     */
+    public String getCatalogObjectNameFromGrant(CatalogObjectGrantMetaData grant) {
+
+        long catalogObjectId = grant.getCatalogObjectId();
+        long bucketId = grant.getCatalogObjectBucketId();
+
+        List<CatalogObjectRevisionEntity> listOfObjects = catalogObjectRevisionRepository.findCatalogObject(catalogObjectId);
+
+        Optional<CatalogObjectRevisionEntity> optCatalogObject = listOfObjects.stream()
+                                                                              .filter(obj -> obj.getCatalogObject()
+                                                                                                .getBucket()
+                                                                                                .getId() == bucketId)
+                                                                              .findFirst();
+
+        if (optCatalogObject.isPresent()) {
+            return optCatalogObject.get().getCatalogObject().getId().getName();
+        } else {
+            throw new DataIntegrityViolationException("Catalog Object not found");
+        }
+    }
+
+    /**
+     *
+     * Check in grants if the user has the minimum required access type for the current task over the specific
+     * catalog object
+     *
+     * @param user authenticated user
+     * @param bucketName name of the bucket
+     * @param catalogObjectName name of the catalog object
+     * @param requiredAccessType minimum required access type
+     * @return true if the user has the minimum grant access type over the current object
+     */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public boolean isTheUserGrantSufficientForTheCurrentTask(AuthenticatedUser user,
+                                                             String bucketName, String catalogObjectName, String requiredAccessType) {
+        long bucketId = bucketRepository.findOneByBucketName(bucketName).getId();
+
+        List<CatalogObjectGrantEntity> grantEntities = catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToABucket(bucketId);
+
+        // Find the catalog object id
+        List<String> bucketsName = new LinkedList<>();
+        bucketsName.add(bucketName);
+        CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
+                                                                                                                                         catalogObjectName);
+        long catalogObjectId = catalogObjectRevisionEntity.getId();
+
+        // Remove all grants that are not assigned to the current user and his group
+        grantEntities.removeIf(catalogObjectGrantEntity -> (((!catalogObjectGrantEntity.getProfiteer()
+                                                                                       .equals(user.getName()) &&
+                                                              catalogObjectGrantEntity.getGrantee().equals("user")) ||
+                                                             (!user.getGroups()
+                                                                   .contains(catalogObjectGrantEntity.getProfiteer()) &&
+                                                              catalogObjectGrantEntity.getGrantee().equals("group"))) &&
+                                                            catalogObjectGrantEntity.getCatalogObjectRevisionEntity()
+                                                                                    .getId() != catalogObjectId));
+
+        CatalogObjectGrantEntity userCatalogObjectGrant;
+
+        if (grantEntities.size() > 0) {
+            userCatalogObjectGrant = grantEntities.get(0);
+            if (!userCatalogObjectGrant.getAccessType().equals(AccessType.ADMIN_ACCESS_TYPE)) {
+                for (int index = 1; index < grantEntities.size(); index++) {
+                    if (getPriorityLevel(userCatalogObjectGrant.getAccessType(),
+                                         grantEntities.get(index).getAccessType()) == 2) {
+                        userCatalogObjectGrant = grantEntities.get(index);
+                    }
+                }
+            } else {
+                // The userCatalogObjectGrant object has an admin grant type - no need to de complementary checks
+                return true;
+            }
+        } else {
+            return false;
+        }
+
+        return grantAccessTypeHelperService.compareGrantAccessType(userCatalogObjectGrant.getAccessType(),
+                                                                   requiredAccessType);
+
+    }
+
+    /**
+     *
+     * Delete all catalog object grants assigned to a specific bucket
+     *
+     * @param bucketId bucket id
+     */
+    public void deleteAllCatalogObjectsGrantsAssignedToABucket(long bucketId) {
+        // Get existing grants
+        List<CatalogObjectGrantEntity> existingCatalogObjectsGrantsToDelete = catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToABucket(bucketId);
+
+        // Delete grants
+        if (existingCatalogObjectsGrantsToDelete != null) {
+            catalogObjectGrantRepository.delete(existingCatalogObjectsGrantsToDelete);
+        }
+    }
+
+    /**
+     *
+     * Delete all catalog object grant assigned to a specific object
+     *
+     * @param bucketId bucket id
+     * @param catalogObjectId catalog object id
+     */
+    public void deleteAllCatalogObjectGrants(long bucketId, long catalogObjectId) {
+        // Get the catalog objects grants
+        List<CatalogObjectGrantEntity> catalogObjectGrants = catalogObjectGrantRepository.findAllGrantsByCatalogObjectIdInBucket(catalogObjectId,
+                                                                                                                                 bucketId);
+
+        if (!catalogObjectGrants.isEmpty()) {
+            catalogObjectGrantRepository.delete(catalogObjectGrants);
+        }
+    }
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
@@ -97,7 +97,7 @@ public class CatalogObjectGrantService {
                                                                                                                                        username,
                                                                                                                                        bucket.getId());
             if (dbCatalogObjectGrantEntityForUser != null &&
-                (dbCatalogObjectGrantEntityForUser.getProfiteer().equals(username) &&
+                (dbCatalogObjectGrantEntityForUser.getGrantee().equals(username) &&
                  dbCatalogObjectGrantEntityForUser.getCatalogObjectRevisionEntity()
                                                   .getId()
                                                   .equals(catalogObjectRevisionEntity.getId()) &&
@@ -117,7 +117,7 @@ public class CatalogObjectGrantService {
                                                                                                                                              groupName,
                                                                                                                                              bucket.getId());
             if (dbCatalogObjectGrantEntityForUserGroup != null &&
-                dbCatalogObjectGrantEntityForUserGroup.getProfiteer().equals(username) &&
+                dbCatalogObjectGrantEntityForUserGroup.getGrantee().equals(username) &&
                 dbCatalogObjectGrantEntityForUserGroup.getCatalogObjectRevisionEntity()
                                                       .getId()
                                                       .equals(catalogObjectRevisionEntity.getId()) &&
@@ -387,11 +387,11 @@ public class CatalogObjectGrantService {
      *
      * Get buckets' id from grants assigned to user group
      *
-     * @param userGroup user group
+     * @param userGroups list of user groups
      * @return the list of bucketIds found in all grants assigned to a user group
      */
-    public List<Long> getAllBucketIdsFromGrantsAssignedToUserGroup(String userGroup) {
-        return catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(userGroup);
+    public List<Long> getAllBucketIdsFromGrantsAssignedToUserGroup(List<String> userGroups) {
+        return catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(userGroups);
     }
 
     /**
@@ -408,9 +408,7 @@ public class CatalogObjectGrantService {
         long bucketId = bucketRepository.findOneByBucketName(bucketName).getId();
 
         Set<Long> buckets = new HashSet<>(catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUsername(user.getName()));
-        for (String group : user.getGroups()) {
-            buckets.addAll(catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(group));
-        }
+        buckets.addAll(catalogObjectGrantRepository.findAllBucketsIdFromCatalogObjectGrantsAssignedToAUserGroup(user.getGroups()));
 
         return buckets.contains(bucketId);
 
@@ -484,11 +482,11 @@ public class CatalogObjectGrantService {
         long catalogObjectId = catalogObjectRevisionEntity.getId();
 
         // Remove all grants that are not assigned to the current user and his group
-        grantEntities.removeIf(catalogObjectGrantEntity -> (((!catalogObjectGrantEntity.getProfiteer()
+        grantEntities.removeIf(catalogObjectGrantEntity -> (((!catalogObjectGrantEntity.getGrantee()
                                                                                        .equals(user.getName()) &&
                                                               catalogObjectGrantEntity.getGrantee().equals("user")) ||
                                                              (!user.getGroups()
-                                                                   .contains(catalogObjectGrantEntity.getProfiteer()) &&
+                                                                   .contains(catalogObjectGrantEntity.getGrantee()) &&
                                                               catalogObjectGrantEntity.getGrantee().equals("group"))) &&
                                                             catalogObjectGrantEntity.getCatalogObjectRevisionEntity()
                                                                                     .getId() != catalogObjectId));

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
@@ -77,7 +77,7 @@ public class CatalogObjectGrantService {
      * @throws DataIntegrityViolationException in case of an internal db query error
      */
     public CatalogObjectGrantMetadata createCatalogObjectGrant(String bucketName, String catalogObjectName,
-                                                               String currentUser, String accessType, String username, String groupName)
+            String currentUser, String accessType, String username, String groupName)
             throws DataIntegrityViolationException {
 
         CatalogObjectGrantEntity catalogObjectGrantEntity = null;
@@ -91,7 +91,7 @@ public class CatalogObjectGrantService {
 
         checkForAvailability(catalogObjectRevisionEntity, bucketName, catalogObjectName);
 
-        if (!username.equals("") && groupName.equals("")) {
+        if (!username.isEmpty() && groupName.isEmpty()) {
             // Case if the grant targets a specific user
             CatalogObjectGrantEntity dbCatalogObjectGrantEntityForUser = catalogObjectGrantRepository.findCatalogObjectGrantByUsername(catalogObjectRevisionEntity.getId(),
                                                                                                                                        username,
@@ -105,13 +105,13 @@ public class CatalogObjectGrantService {
                 throw new CatalogObjectGrantAlreadyExistsException(catalogObjectName, bucketName, username);
             }
             catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
-                    currentUser,
+                                                                    currentUser,
                                                                     username,
                                                                     accessType,
                                                                     catalogObjectRevisionEntity,
                                                                     bucket);
 
-        } else if (username.equals("") && !groupName.equals("")) {
+        } else if (username.isEmpty() && !groupName.isEmpty()) {
             // Case if the grant targets a specific user group
             CatalogObjectGrantEntity dbCatalogObjectGrantEntityForUserGroup = catalogObjectGrantRepository.findCatalogObjectGrantByUserGroup(catalogObjectRevisionEntity.getId(),
                                                                                                                                              groupName,
@@ -126,7 +126,7 @@ public class CatalogObjectGrantService {
             }
             // BucketGrant attributes: Type, Profiteer, Access Type and the Bucket
             catalogObjectGrantEntity = new CatalogObjectGrantEntity("group",
-                    currentUser,
+                                                                    currentUser,
                                                                     groupName,
                                                                     accessType,
                                                                     catalogObjectRevisionEntity,
@@ -146,7 +146,7 @@ public class CatalogObjectGrantService {
      * @return an empty catalog grant metadata if the deletion process was successful
      */
     public CatalogObjectGrantMetadata deleteCatalogObjectGrant(String bucketName, String catalogObjectName,
-                                                               String username, String groupName) {
+            String username, String groupName) {
 
         List<String> bucketsName = new LinkedList<>();
         bucketsName.add(bucketName);
@@ -160,12 +160,12 @@ public class CatalogObjectGrantService {
         CatalogObjectGrantEntity catalogObjectGrantEntity = null;
 
         assert bucket != null;
-        if (!username.equals("") && groupName.equals("")) {
+        if (!username.isEmpty() && groupName.isEmpty()) {
             // Case if the grant targets a specific user
             catalogObjectGrantEntity = catalogObjectGrantRepository.findCatalogObjectGrantByUsername(catalogObjectRevisionEntity.getId(),
                                                                                                      username,
                                                                                                      bucket.getId());
-        } else if (username.equals("") && !groupName.equals("")) {
+        } else if (username.isEmpty() && !groupName.isEmpty()) {
             catalogObjectGrantEntity = catalogObjectGrantRepository.findCatalogObjectGrantByUserGroup(catalogObjectRevisionEntity.getId(),
                                                                                                       groupName,
                                                                                                       bucket.getId());
@@ -193,7 +193,7 @@ public class CatalogObjectGrantService {
      * @return the updated grant
      */
     public CatalogObjectGrantMetadata updateCatalogObjectGrant(String username, String groupName,
-                                                               String catalogObjectName, String bucketName, String accessType) {
+            String catalogObjectName, String bucketName, String accessType) {
 
         List<String> bucketsName = new LinkedList<>();
         bucketsName.add(bucketName);
@@ -206,12 +206,12 @@ public class CatalogObjectGrantService {
 
         CatalogObjectGrantEntity catalogObjectGrantEntity = null;
 
-        if (!username.equals("") && groupName.equals("")) {
+        if (!username.isEmpty() && groupName.isEmpty()) {
             // Case if the grant targets a specific user
             catalogObjectGrantEntity = catalogObjectGrantRepository.findCatalogObjectGrantByUsername(catalogObjectRevisionEntity.getId(),
                                                                                                      username,
                                                                                                      bucket.getId());
-        } else if (username.equals("") && !groupName.equals("")) {
+        } else if (username.isEmpty() && !groupName.isEmpty()) {
             // Case if the grant targets a specific user group
             catalogObjectGrantEntity = catalogObjectGrantRepository.findCatalogObjectGrantByUserGroup(catalogObjectRevisionEntity.getId(),
                                                                                                       groupName,
@@ -266,7 +266,7 @@ public class CatalogObjectGrantService {
 
         // Check for duplicates grants in the group grant
         // We check the access type and compare them to add only the higher access grant
-        if (dbGroupCatalogObjectGrants!=null && !dbGroupCatalogObjectGrants.isEmpty()) {
+        if (dbGroupCatalogObjectGrants != null && !dbGroupCatalogObjectGrants.isEmpty()) {
             for (CatalogObjectGrantEntity groupObjectGrant : dbGroupCatalogObjectGrants) {
                 for (CatalogObjectGrantEntity userObjectGrant : dbUserCatalogObjectGrants) {
                     if (!groupObjectGrant.getAccessType().equals(userObjectGrant.getAccessType())) {
@@ -275,7 +275,8 @@ public class CatalogObjectGrantService {
                         String userGroupGrantAccessType = groupObjectGrant.getAccessType();
                         // Compare the access type and add the higher one
                         // If priority level equals 2 ==> Group grant is higher than the user
-                        if (grantAccessTypeHelperService.getPriorityLevel(userGrantAccessType, userGroupGrantAccessType) == 2) {
+                        if (grantAccessTypeHelperService.getPriorityLevel(userGrantAccessType,
+                                                                          userGroupGrantAccessType) == 2) {
                             // Add the group grant
                             result.add(groupObjectGrant);
                         } else {
@@ -287,10 +288,10 @@ public class CatalogObjectGrantService {
                     }
                 }
             }
-        } else if(dbUserCatalogObjectGrants!=null && !dbUserCatalogObjectGrants.isEmpty()){
+        } else if (dbUserCatalogObjectGrants != null && !dbUserCatalogObjectGrants.isEmpty()) {
             result.addAll(dbUserCatalogObjectGrants);
         }
-        if(!result.isEmpty()) {
+        if (!result.isEmpty()) {
             return result.stream().map(CatalogObjectGrantMetadata::new).collect(Collectors.toList());
         } else {
             return new LinkedList<>();
@@ -298,10 +299,10 @@ public class CatalogObjectGrantService {
     }
 
     public List<CatalogObjectGrantMetadata> getAllCreatedCatalogObjectGrantsForThisBucket(String username,
-                                                                                          String bucketName) {
+            String bucketName) {
         BucketEntity bucket = bucketRepository.findOneByBucketName(bucketName);
         List<CatalogObjectGrantEntity> dbUserCreatedCatalogObjectGrants = catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(username,
-                                                                                                                                                                     bucket.getId());
+                                                                                                                                                                bucket.getId());
         return dbUserCreatedCatalogObjectGrants.stream()
                                                .map(CatalogObjectGrantMetadata::new)
                                                .collect(Collectors.toList());
@@ -424,7 +425,7 @@ public class CatalogObjectGrantService {
      */
     public List<CatalogObjectGrantMetadata> findAllCatalogObjectGrantsAssignedToABucket(String bucketName) {
         return catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByBucketEntityId(bucketRepository.findOneByBucketName(bucketName)
-                                                                                                        .getId())
+                                                                                                           .getId())
                                            .stream()
                                            .map(CatalogObjectGrantMetadata::new)
                                            .collect(Collectors.toList());
@@ -469,8 +470,8 @@ public class CatalogObjectGrantService {
      * @return true if the user has the minimum grant access type over the current object
      */
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public boolean isTheUserGrantSufficientForTheCurrentTask(AuthenticatedUser user,
-                                                             String bucketName, String catalogObjectName, String requiredAccessType) {
+    public boolean isTheUserGrantSufficientForTheCurrentTask(AuthenticatedUser user, String bucketName,
+            String catalogObjectName, String requiredAccessType) {
         long bucketId = bucketRepository.findOneByBucketName(bucketName).getId();
 
         List<CatalogObjectGrantEntity> grantEntities = catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByBucketEntityId(bucketId);
@@ -499,7 +500,7 @@ public class CatalogObjectGrantService {
             if (!userCatalogObjectGrant.getAccessType().equals(admin.toString())) {
                 for (int index = 1; index < grantEntities.size(); index++) {
                     if (grantAccessTypeHelperService.getPriorityLevel(userCatalogObjectGrant.getAccessType(),
-                                         grantEntities.get(index).getAccessType()) == 2) {
+                                                                      grantEntities.get(index).getAccessType()) == 2) {
                         userCatalogObjectGrant = grantEntities.get(index);
                     }
                 }
@@ -542,7 +543,7 @@ public class CatalogObjectGrantService {
     public void deleteAllCatalogObjectGrants(long bucketId, long catalogObjectId) {
         // Get the catalog objects grants
         List<CatalogObjectGrantEntity> catalogObjectGrants = catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(catalogObjectId,
-                                                                                                                                 bucketId);
+                                                                                                                                                                         bucketId);
 
         if (!catalogObjectGrants.isEmpty()) {
             catalogObjectGrantRepository.delete(catalogObjectGrants);

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -548,11 +548,11 @@ public class CatalogObjectService {
                                                                                                                                              name);
             long catalogObjectId = catalogObjectRevisionEntity.getId();
 
-            // Delete the catalog Object
-            catalogObjectRepository.delete(new CatalogObjectEntity.CatalogObjectEntityKey(bucketEntity.getId(), name));
-
             //Delete all object grants
             catalogObjectGrantService.deleteAllCatalogObjectGrants(bucketId, catalogObjectId);
+
+            // Delete the catalog Object
+            catalogObjectRepository.delete(new CatalogObjectEntity.CatalogObjectEntityKey(bucketEntity.getId(), name));
         } catch (EmptyResultDataAccessException emptyResultDataAccessException) {
             log.warn("CatalogObject {} does not exist in bucket {}", name, bucketName);
             throw new CatalogObjectNotFoundException(bucketName, name);

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -117,6 +117,9 @@ public class CatalogObjectService {
     @Autowired
     private SeparatorUtility separatorUtility;
 
+    @Autowired
+    CatalogObjectGrantService catalogObjectGrantService;
+
     @Value("${kind.separator}")
     protected String kindSeparator;
 
@@ -535,7 +538,21 @@ public class CatalogObjectService {
         BucketEntity bucketEntity = findBucketByNameAndCheck(bucketName);
         CatalogObjectMetadata catalogObjectMetadata = getCatalogObjectMetadata(bucketName, name);
         try {
+            // Get the bucketId
+            long bucketId = bucketEntity.getId();
+
+            // Find the catalog object id
+            List<String> bucketsName = new LinkedList<>();
+            bucketsName.add(bucketName);
+            CatalogObjectRevisionEntity catalogObjectRevisionEntity = catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(bucketsName,
+                                                                                                                                             name);
+            long catalogObjectId = catalogObjectRevisionEntity.getId();
+
+            // Delete the catalog Object
             catalogObjectRepository.delete(new CatalogObjectEntity.CatalogObjectEntityKey(bucketEntity.getId(), name));
+
+            //Delete all object grants
+            catalogObjectGrantService.deleteAllCatalogObjectGrants(bucketId, catalogObjectId);
         } catch (EmptyResultDataAccessException emptyResultDataAccessException) {
             log.warn("CatalogObject {} does not exist in bucket {}", name, bucketName);
             throw new CatalogObjectNotFoundException(bucketName, name);

--- a/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
@@ -42,16 +42,31 @@ public class GrantAccessTypeHelperService {
         // If user grant exists over this bucket, check the access type
         // else check the access type of the user group grant over this bucket
         // if both case are false ==> no grants assigned to this user over this bucket
-        switch (requiredAccessType) {
-            case READ_ACCESS_TYPE:
-                return currentAccessType.equals(READ_ACCESS_TYPE) || currentAccessType.equals(WRITE_ACCESS_TYPE) ||
-                       currentAccessType.equals(ADMIN_ACCESS_TYPE);
-            case WRITE_ACCESS_TYPE:
-                return currentAccessType.equals(WRITE_ACCESS_TYPE) || currentAccessType.equals(ADMIN_ACCESS_TYPE);
-            case ADMIN_ACCESS_TYPE:
-                return currentAccessType.equals(ADMIN_ACCESS_TYPE);
-            default:
-                return false;
+        if(requiredAccessType.equals(admin.toString())){
+            return currentAccessType.equals(admin.toString());
+        } else if(requiredAccessType.equals(write.toString())){
+            return currentAccessType.equals(write.toString()) || currentAccessType.equals(admin.toString());
+        } else if(requiredAccessType.equals(read.toString())){
+            return currentAccessType.equals(read.toString()) || currentAccessType.equals(write.toString()) ||
+                    currentAccessType.equals(admin.toString());
+        } else {
+            return false;
         }
+    }
+
+    /**
+     *
+     * @param accessType1 first access type
+     * @param accessType2 second access type
+     * @return 1 if the first access type is higher than the second and 2 in opposite case
+     */
+    public int getPriorityLevel(String accessType1, String accessType2) {
+        int priority = 1;
+        if(accessType1.equals(read.toString()) && (accessType2.equals(admin.toString()) || accessType2.equals(write.toString()))){
+            priority = 2;
+        } else if (accessType1.equals(write.toString()) && accessType2.equals(admin.toString())){
+            priority = 2;
+        }
+        return priority;
     }
 }

--- a/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
@@ -42,13 +42,13 @@ public class GrantAccessTypeHelperService {
         // If user grant exists over this bucket, check the access type
         // else check the access type of the user group grant over this bucket
         // if both case are false ==> no grants assigned to this user over this bucket
-        if(requiredAccessType.equals(admin.toString())){
+        if (requiredAccessType.equals(admin.toString())) {
             return currentAccessType.equals(admin.toString());
-        } else if(requiredAccessType.equals(write.toString())){
+        } else if (requiredAccessType.equals(write.toString())) {
             return currentAccessType.equals(write.toString()) || currentAccessType.equals(admin.toString());
-        } else if(requiredAccessType.equals(read.toString())){
+        } else if (requiredAccessType.equals(read.toString())) {
             return currentAccessType.equals(read.toString()) || currentAccessType.equals(write.toString()) ||
-                    currentAccessType.equals(admin.toString());
+                   currentAccessType.equals(admin.toString());
         } else {
             return false;
         }
@@ -62,9 +62,10 @@ public class GrantAccessTypeHelperService {
      */
     public int getPriorityLevel(String accessType1, String accessType2) {
         int priority = 1;
-        if(accessType1.equals(read.toString()) && (accessType2.equals(admin.toString()) || accessType2.equals(write.toString()))){
+        if (accessType1.equals(read.toString()) &&
+            (accessType2.equals(admin.toString()) || accessType2.equals(write.toString()))) {
             priority = 2;
-        } else if (accessType1.equals(write.toString()) && accessType2.equals(admin.toString())){
+        } else if (accessType1.equals(write.toString()) && accessType2.equals(admin.toString())) {
             priority = 2;
         }
         return priority;

--- a/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
@@ -1,0 +1,57 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service;
+
+import static org.ow2.proactive.catalog.util.AccessType.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.log4j.Log4j2;
+
+
+@Log4j2
+@Service
+@Transactional
+public class GrantAccessTypeHelperService {
+
+    public boolean compareGrantAccessType(String currentAccessType, String requiredAccessType) {
+        // If user grant exists over this bucket, check the access type
+        // else check the access type of the user group grant over this bucket
+        // if both case are false ==> no grants assigned to this user over this bucket
+        switch (requiredAccessType) {
+            case READ_ACCESS_TYPE:
+                return currentAccessType.equals(READ_ACCESS_TYPE) || currentAccessType.equals(WRITE_ACCESS_TYPE) ||
+                       currentAccessType.equals(ADMIN_ACCESS_TYPE);
+            case WRITE_ACCESS_TYPE:
+                return currentAccessType.equals(WRITE_ACCESS_TYPE) || currentAccessType.equals(ADMIN_ACCESS_TYPE);
+            case ADMIN_ACCESS_TYPE:
+                return currentAccessType.equals(ADMIN_ACCESS_TYPE);
+            default:
+                return false;
+        }
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/RestApiAccessService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/RestApiAccessService.java
@@ -94,6 +94,28 @@ public class RestApiAccessService {
         return restApiAccessResponse;
     }
 
+    public AuthenticatedUser getUserFromSessionId(String sessionId) {
+        return schedulerUserAuthenticationService.authenticateBySessionId(sessionId);
+    }
+
+    public boolean isUserSessionActive(String sessionId, String username) {
+        AuthenticatedUser authenticatedUser = schedulerUserAuthenticationService.authenticateBySessionId(sessionId);
+        if (authenticatedUser.getName().equals(username)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public boolean isSessionActive(String sessionId) {
+        AuthenticatedUser authenticatedUser = schedulerUserAuthenticationService.authenticateBySessionId(sessionId);
+        if (authenticatedUser != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public boolean isBucketAccessibleByUser(boolean sessionIdRequired, String sessionId, String bucketName) {
         if (!isAPublicBucket(bucketName) && sessionIdRequired) {
             return this.checkAccessBySessionForBucketToOwnerOrGroup(sessionId, bucketName).isAuthorized();

--- a/src/main/java/org/ow2/proactive/catalog/service/exception/BucketGrantAccessException.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/exception/BucketGrantAccessException.java
@@ -1,0 +1,36 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service.exception;
+
+import org.ow2.proactive.microservices.common.exception.ClientException;
+
+
+public class BucketGrantAccessException extends ClientException {
+
+    public BucketGrantAccessException(String bucketName) {
+        super("You don't have grant access with admin rights over the bucket: " + bucketName);
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/exception/BucketGrantAlreadyExistsException.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/exception/BucketGrantAlreadyExistsException.java
@@ -1,0 +1,36 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service.exception;
+
+import org.ow2.proactive.microservices.common.exception.ClientException;
+
+
+public class BucketGrantAlreadyExistsException extends ClientException {
+
+    public BucketGrantAlreadyExistsException(String bucketName, String name) {
+        super("Grant for: " + name + " already exists and attached to the bucket: " + bucketName);
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/exception/CatalogObjectGrantAccessException.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/exception/CatalogObjectGrantAccessException.java
@@ -1,0 +1,37 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service.exception;
+
+import org.ow2.proactive.microservices.common.exception.ClientException;
+
+
+public class CatalogObjectGrantAccessException extends ClientException {
+
+    public CatalogObjectGrantAccessException(String bucketName, String catalogObjectName) {
+        super("You don't have grant access with admin rights over the catalog object: " + catalogObjectName +
+              " in the bucket: " + bucketName);
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/exception/CatalogObjectGrantAlreadyExistsException.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/exception/CatalogObjectGrantAlreadyExistsException.java
@@ -1,0 +1,38 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service.exception;
+
+import org.ow2.proactive.microservices.common.exception.ClientException;
+
+
+public class CatalogObjectGrantAlreadyExistsException extends ClientException {
+
+    public CatalogObjectGrantAlreadyExistsException(String catalogObjectName, String bucketName, String name) {
+        super("Grant exists for WF: " + catalogObjectName + " in bucket: " + bucketName +
+              " and already assigned to user or user group: " + name);
+    }
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/util/AccessType.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/AccessType.java
@@ -1,0 +1,33 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.util;
+
+// TODO Transform into Enum
+public class AccessType {
+    public static final String ADMIN_ACCESS_TYPE = "admin";
+    public static final String WRITE_ACCESS_TYPE = "write";
+    public static final String READ_ACCESS_TYPE = "read";
+}

--- a/src/main/java/org/ow2/proactive/catalog/util/AccessType.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/AccessType.java
@@ -26,5 +26,7 @@
 package org.ow2.proactive.catalog.util;
 
 public enum AccessType {
-    admin, write, read
+    admin,
+    write,
+    read
 }

--- a/src/main/java/org/ow2/proactive/catalog/util/AccessType.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/AccessType.java
@@ -25,9 +25,6 @@
  */
 package org.ow2.proactive.catalog.util;
 
-// TODO Transform into Enum
-public class AccessType {
-    public static final String ADMIN_ACCESS_TYPE = "admin";
-    public static final String WRITE_ACCESS_TYPE = "write";
-    public static final String READ_ACCESS_TYPE = "read";
+public enum AccessType {
+    admin, write, read
 }

--- a/src/test/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectEntityTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectEntityTest.java
@@ -105,6 +105,7 @@ public class CatalogObjectEntityTest {
                                                time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
                                                catalogObject,
                                                Collections.emptyList(),
-                                               new byte[0], new LinkedHashSet<>());
+                                               new byte[0],
+                                               new LinkedHashSet<>());
     }
 }

--- a/src/test/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectEntityTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/repository/entity/CatalogObjectEntityTest.java
@@ -30,10 +30,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -108,6 +105,6 @@ public class CatalogObjectEntityTest {
                                                time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
                                                catalogObject,
                                                Collections.emptyList(),
-                                               new byte[0]);
+                                               new byte[0], new LinkedHashSet<>());
     }
 }

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketControllerTest.java
@@ -25,8 +25,8 @@
  */
 package org.ow2.proactive.catalog.rest.controller;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
@@ -35,7 +35,9 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.ow2.proactive.catalog.service.BucketGrantService;
 import org.ow2.proactive.catalog.service.BucketService;
+import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
 import org.ow2.proactive.catalog.service.RestApiAccessService;
 
 
@@ -53,9 +55,23 @@ public class BucketControllerTest {
     @Mock
     private RestApiAccessService restApiAccessService;
 
+    @Mock
+    private BucketGrantService bucketGrantService;
+
+    @Mock
+    private CatalogObjectGrantService catalogObjectGrantService;
+
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
+        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(),
+                                                                                                       any(),
+                                                                                                       any())).thenReturn(true);
+        when(catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(any(),
+                                                                                                                        any(),
+                                                                                                                        any())).thenReturn(true);
+        when(catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(any(),
+                                                                                                 any())).thenReturn(true);
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketControllerTest.java
@@ -64,9 +64,7 @@ public class BucketControllerTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(),
-                                                                                                       any(),
-                                                                                                       any())).thenReturn(true);
+        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(), any(), any())).thenReturn(true);
         when(catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(any(),
                                                                                                                         any(),
                                                                                                                         any())).thenReturn(true);

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketGrantControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketGrantControllerTest.java
@@ -1,0 +1,88 @@
+package org.ow2.proactive.catalog.rest.controller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.ow2.proactive.catalog.service.BucketGrantService;
+import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
+import org.ow2.proactive.catalog.service.RestApiAccessService;
+
+import static org.mockito.Mockito.*;
+
+public class BucketGrantControllerTest{
+
+    @InjectMocks
+    BucketGrantController bucketGrantController;
+
+    @Mock
+    private RestApiAccessService restApiAccessService;
+
+    @Mock
+    private BucketGrantService bucketGrantService;
+
+    @Mock
+    private CatalogObjectGrantService catalogObjectGrantService;
+
+    private final String DUMMY_SESSION_ID = "12345";
+
+    private final String DUMMY_BUCKET_NAME = "dummy-bucket";
+
+    private final String DUMMY_CURRENT_USER = "dummyAdmin";
+
+    private final String DUMMY_ACCESS_TYPE = "admin";
+
+    private final String DUMMY_USER = "dummyUser";
+
+    private final String DUMMY_GROUP = "dummyGroup";
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(),
+                any(),
+                any())).thenReturn(true);
+        when(catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(any(),
+                any(),
+                any())).thenReturn(true);
+        when(catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(any(),
+                any())).thenReturn(true);
+    }
+
+    @Test
+    public void testGetAssignedBucketGrantsForUserAndHisGroup() {
+        bucketGrantController.getAssignedBucketGrantsForUserAndHisGroup(DUMMY_SESSION_ID, DUMMY_CURRENT_USER, DUMMY_GROUP);
+        verify(bucketGrantService, times(1)).getAllAssignedGrantsForUserAndHisGroup(DUMMY_CURRENT_USER, DUMMY_GROUP);
+    }
+
+    @Test
+    public void testUpdateBucketGrant() {
+        bucketGrantController.updateBucketGrant(DUMMY_SESSION_ID, DUMMY_CURRENT_USER, DUMMY_USER, "", DUMMY_ACCESS_TYPE, DUMMY_BUCKET_NAME);
+        verify(bucketGrantService, times(1)).updateBucketGrantForASpecificUser(DUMMY_BUCKET_NAME, DUMMY_USER, DUMMY_ACCESS_TYPE);
+        bucketGrantController.updateBucketGrant(DUMMY_SESSION_ID, DUMMY_CURRENT_USER, "", DUMMY_GROUP, DUMMY_ACCESS_TYPE, DUMMY_BUCKET_NAME);
+        verify(bucketGrantService, times(1)).updateBucketGrantForASpecificUserGroup(DUMMY_BUCKET_NAME, DUMMY_GROUP, DUMMY_ACCESS_TYPE);
+    }
+
+    @Test
+    public void testGetCreatedBucketGrants() {
+        bucketGrantController.getCreatedBucketGrants(DUMMY_SESSION_ID, DUMMY_CURRENT_USER);
+        verify(bucketGrantService, times(1)).getAllGrantsCreatedByUsername(DUMMY_CURRENT_USER);
+    }
+
+    @Test
+    public void testCreateBucketGrant() {
+        bucketGrantController.createBucketGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, DUMMY_USER, "");
+        verify(bucketGrantService, times(1)).createBucketGrant(DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, DUMMY_USER, "");
+        bucketGrantController.createBucketGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
+        verify(bucketGrantService, times(1)).createBucketGrant(DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
+    }
+
+    @Test
+    public void testDeleteBucketGrant() {
+        bucketGrantController.deleteBucketGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_USER, "");
+        verify(bucketGrantService, times(1)).deleteBucketGrant(DUMMY_BUCKET_NAME, DUMMY_USER, "");
+        bucketGrantController.deleteBucketGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, "", DUMMY_GROUP);
+        verify(bucketGrantService, times(1)).deleteBucketGrant(DUMMY_BUCKET_NAME, "", DUMMY_GROUP);
+    }
+}

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketGrantControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketGrantControllerTest.java
@@ -1,4 +1,31 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
 package org.ow2.proactive.catalog.rest.controller;
+
+import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -9,9 +36,8 @@ import org.ow2.proactive.catalog.service.BucketGrantService;
 import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
 import org.ow2.proactive.catalog.service.RestApiAccessService;
 
-import static org.mockito.Mockito.*;
 
-public class BucketGrantControllerTest{
+public class BucketGrantControllerTest {
 
     @InjectMocks
     BucketGrantController bucketGrantController;
@@ -40,28 +66,42 @@ public class BucketGrantControllerTest{
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(),
-                any(),
-                any())).thenReturn(true);
+        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(), any(), any())).thenReturn(true);
         when(catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(any(),
-                any(),
-                any())).thenReturn(true);
+                                                                                                                        any(),
+                                                                                                                        any())).thenReturn(true);
         when(catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(any(),
-                any())).thenReturn(true);
+                                                                                                 any())).thenReturn(true);
     }
 
     @Test
     public void testGetAssignedBucketGrantsForUserAndHisGroup() {
-        bucketGrantController.getAssignedBucketGrantsForUserAndHisGroup(DUMMY_SESSION_ID, DUMMY_CURRENT_USER, DUMMY_GROUP);
+        bucketGrantController.getAssignedBucketGrantsForUserAndHisGroup(DUMMY_SESSION_ID,
+                                                                        DUMMY_CURRENT_USER,
+                                                                        DUMMY_GROUP);
         verify(bucketGrantService, times(1)).getAllAssignedGrantsForUserAndHisGroup(DUMMY_CURRENT_USER, DUMMY_GROUP);
     }
 
     @Test
     public void testUpdateBucketGrant() {
-        bucketGrantController.updateBucketGrant(DUMMY_SESSION_ID, DUMMY_CURRENT_USER, DUMMY_USER, "", DUMMY_ACCESS_TYPE, DUMMY_BUCKET_NAME);
-        verify(bucketGrantService, times(1)).updateBucketGrantForASpecificUser(DUMMY_BUCKET_NAME, DUMMY_USER, DUMMY_ACCESS_TYPE);
-        bucketGrantController.updateBucketGrant(DUMMY_SESSION_ID, DUMMY_CURRENT_USER, "", DUMMY_GROUP, DUMMY_ACCESS_TYPE, DUMMY_BUCKET_NAME);
-        verify(bucketGrantService, times(1)).updateBucketGrantForASpecificUserGroup(DUMMY_BUCKET_NAME, DUMMY_GROUP, DUMMY_ACCESS_TYPE);
+        bucketGrantController.updateBucketGrant(DUMMY_SESSION_ID,
+                                                DUMMY_CURRENT_USER,
+                                                DUMMY_USER,
+                                                "",
+                                                DUMMY_ACCESS_TYPE,
+                                                DUMMY_BUCKET_NAME);
+        verify(bucketGrantService, times(1)).updateBucketGrantForASpecificUser(DUMMY_BUCKET_NAME,
+                                                                               DUMMY_USER,
+                                                                               DUMMY_ACCESS_TYPE);
+        bucketGrantController.updateBucketGrant(DUMMY_SESSION_ID,
+                                                DUMMY_CURRENT_USER,
+                                                "",
+                                                DUMMY_GROUP,
+                                                DUMMY_ACCESS_TYPE,
+                                                DUMMY_BUCKET_NAME);
+        verify(bucketGrantService, times(1)).updateBucketGrantForASpecificUserGroup(DUMMY_BUCKET_NAME,
+                                                                                    DUMMY_GROUP,
+                                                                                    DUMMY_ACCESS_TYPE);
     }
 
     @Test
@@ -72,17 +112,43 @@ public class BucketGrantControllerTest{
 
     @Test
     public void testCreateBucketGrant() {
-        bucketGrantController.createBucketGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, DUMMY_USER, "");
-        verify(bucketGrantService, times(1)).createBucketGrant(DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, DUMMY_USER, "");
-        bucketGrantController.createBucketGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
-        verify(bucketGrantService, times(1)).createBucketGrant(DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
+        bucketGrantController.createBucketGrant(DUMMY_SESSION_ID,
+                                                DUMMY_BUCKET_NAME,
+                                                DUMMY_CURRENT_USER,
+                                                DUMMY_ACCESS_TYPE,
+                                                DUMMY_USER,
+                                                "");
+        verify(bucketGrantService, times(1)).createBucketGrant(DUMMY_BUCKET_NAME,
+                                                               DUMMY_CURRENT_USER,
+                                                               DUMMY_ACCESS_TYPE,
+                                                               DUMMY_USER,
+                                                               "");
+        bucketGrantController.createBucketGrant(DUMMY_SESSION_ID,
+                                                DUMMY_BUCKET_NAME,
+                                                DUMMY_CURRENT_USER,
+                                                DUMMY_ACCESS_TYPE,
+                                                "",
+                                                DUMMY_GROUP);
+        verify(bucketGrantService, times(1)).createBucketGrant(DUMMY_BUCKET_NAME,
+                                                               DUMMY_CURRENT_USER,
+                                                               DUMMY_ACCESS_TYPE,
+                                                               "",
+                                                               DUMMY_GROUP);
     }
 
     @Test
     public void testDeleteBucketGrant() {
-        bucketGrantController.deleteBucketGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, DUMMY_USER, "");
+        bucketGrantController.deleteBucketGrant(DUMMY_SESSION_ID,
+                                                DUMMY_BUCKET_NAME,
+                                                DUMMY_CURRENT_USER,
+                                                DUMMY_USER,
+                                                "");
         verify(bucketGrantService, times(1)).deleteBucketGrant(DUMMY_BUCKET_NAME, DUMMY_USER, "");
-        bucketGrantController.deleteBucketGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER, "", DUMMY_GROUP);
+        bucketGrantController.deleteBucketGrant(DUMMY_SESSION_ID,
+                                                DUMMY_BUCKET_NAME,
+                                                DUMMY_CURRENT_USER,
+                                                "",
+                                                DUMMY_GROUP);
         verify(bucketGrantService, times(1)).deleteBucketGrant(DUMMY_BUCKET_NAME, "", DUMMY_GROUP);
     }
 }

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketGrantControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketGrantControllerTest.java
@@ -27,6 +27,9 @@ package org.ow2.proactive.catalog.rest.controller;
 
 import static org.mockito.Mockito.*;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -76,10 +79,12 @@ public class BucketGrantControllerTest {
 
     @Test
     public void testGetAssignedBucketGrantsForUserAndHisGroup() {
+        List<String> userGroups = new LinkedList<>();
+        userGroups.add(DUMMY_GROUP);
         bucketGrantController.getAssignedBucketGrantsForUserAndHisGroup(DUMMY_SESSION_ID,
                                                                         DUMMY_CURRENT_USER,
-                                                                        DUMMY_GROUP);
-        verify(bucketGrantService, times(1)).getAllAssignedGrantsForUserAndHisGroup(DUMMY_CURRENT_USER, DUMMY_GROUP);
+                                                                        userGroups);
+        verify(bucketGrantService, times(1)).getAllAssignedGrantsForUserAndHisGroups(DUMMY_CURRENT_USER, userGroups);
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
@@ -103,9 +103,7 @@ public class CatalogObjectControllerTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(),
-                                                                                                       any(),
-                                                                                                       any())).thenReturn(true);
+        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(), any(), any())).thenReturn(true);
         when(catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(any(),
                                                                                                                         any(),
                                                                                                                         any())).thenReturn(true);

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
@@ -44,15 +44,19 @@ import java.util.Optional;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
 import org.ow2.proactive.catalog.dto.CatalogRawObject;
 import org.ow2.proactive.catalog.repository.BucketRepository;
 import org.ow2.proactive.catalog.repository.entity.BucketEntity;
+import org.ow2.proactive.catalog.service.BucketGrantService;
+import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
 import org.ow2.proactive.catalog.service.CatalogObjectService;
 import org.ow2.proactive.catalog.service.RestApiAccessService;
 import org.ow2.proactive.catalog.service.exception.AccessDeniedException;
@@ -89,6 +93,25 @@ public class CatalogObjectControllerTest {
     private RestApiAccessService restApiAccessService;
 
     private static final String PROJECT_NAME = "projectName";
+
+    @Mock
+    private BucketGrantService bucketGrantService;
+
+    @Mock
+    private CatalogObjectGrantService catalogObjectGrantService;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(),
+                                                                                                       any(),
+                                                                                                       any())).thenReturn(true);
+        when(catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(any(),
+                                                                                                                        any(),
+                                                                                                                        any())).thenReturn(true);
+        when(catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(any(),
+                                                                                                 any())).thenReturn(true);
+    }
 
     @Test
     public void testGetCatalogObjectsAsArchive() throws IOException, NotAuthenticatedException, AccessDeniedException {

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantControllerTest.java
@@ -1,4 +1,32 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
 package org.ow2.proactive.catalog.rest.controller;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -9,8 +37,6 @@ import org.ow2.proactive.catalog.service.BucketGrantService;
 import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
 import org.ow2.proactive.catalog.service.RestApiAccessService;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
 
 public class CatalogObjectGrantControllerTest {
 
@@ -41,42 +67,89 @@ public class CatalogObjectGrantControllerTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(),
-                any(),
-                any())).thenReturn(true);
+        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(), any(), any())).thenReturn(true);
         when(catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(any(),
-                any(),
-                any())).thenReturn(true);
+                                                                                                                        any(),
+                                                                                                                        any())).thenReturn(true);
         when(catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(any(),
-                any())).thenReturn(true);
+                                                                                                 any())).thenReturn(true);
     }
 
     @Test
     public void testCreateCatalogObjectGrant() {
         String DUMMY_ACCESS_TYPE = "admin";
-        catalogObjectGrantController.createCatalogObjectGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, DUMMY_USER, "");
-        verify(catalogObjectGrantService, times(1)).createCatalogObjectGrant(DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, DUMMY_USER, "");
-        catalogObjectGrantController.createCatalogObjectGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
-        verify(catalogObjectGrantService, times(1)).createCatalogObjectGrant(DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
+        catalogObjectGrantController.createCatalogObjectGrant(DUMMY_SESSION_ID,
+                                                              DUMMY_BUCKET_NAME,
+                                                              DUMMY_OBJECT,
+                                                              DUMMY_CURRENT_USER,
+                                                              DUMMY_ACCESS_TYPE,
+                                                              DUMMY_USER,
+                                                              "");
+        verify(catalogObjectGrantService, times(1)).createCatalogObjectGrant(DUMMY_BUCKET_NAME,
+                                                                             DUMMY_OBJECT,
+                                                                             DUMMY_CURRENT_USER,
+                                                                             DUMMY_ACCESS_TYPE,
+                                                                             DUMMY_USER,
+                                                                             "");
+        catalogObjectGrantController.createCatalogObjectGrant(DUMMY_SESSION_ID,
+                                                              DUMMY_BUCKET_NAME,
+                                                              DUMMY_OBJECT,
+                                                              DUMMY_CURRENT_USER,
+                                                              DUMMY_ACCESS_TYPE,
+                                                              "",
+                                                              DUMMY_GROUP);
+        verify(catalogObjectGrantService, times(1)).createCatalogObjectGrant(DUMMY_BUCKET_NAME,
+                                                                             DUMMY_OBJECT,
+                                                                             DUMMY_CURRENT_USER,
+                                                                             DUMMY_ACCESS_TYPE,
+                                                                             "",
+                                                                             DUMMY_GROUP);
     }
 
     @Test
     public void testDeleteCatalogObjectGrant() {
-        catalogObjectGrantController.deleteCatalogObjectGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_USER, "");
-        verify(catalogObjectGrantService, times(1)).deleteCatalogObjectGrant(DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_USER, "");
-        catalogObjectGrantController.deleteCatalogObjectGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, "", DUMMY_GROUP);
-        verify(catalogObjectGrantService, times(1)).deleteCatalogObjectGrant(DUMMY_BUCKET_NAME, DUMMY_OBJECT, "", DUMMY_GROUP);
+        catalogObjectGrantController.deleteCatalogObjectGrant(DUMMY_SESSION_ID,
+                                                              DUMMY_BUCKET_NAME,
+                                                              DUMMY_OBJECT,
+                                                              DUMMY_CURRENT_USER,
+                                                              DUMMY_USER,
+                                                              "");
+        verify(catalogObjectGrantService, times(1)).deleteCatalogObjectGrant(DUMMY_BUCKET_NAME,
+                                                                             DUMMY_OBJECT,
+                                                                             DUMMY_USER,
+                                                                             "");
+        catalogObjectGrantController.deleteCatalogObjectGrant(DUMMY_SESSION_ID,
+                                                              DUMMY_BUCKET_NAME,
+                                                              DUMMY_OBJECT,
+                                                              DUMMY_CURRENT_USER,
+                                                              "",
+                                                              DUMMY_GROUP);
+        verify(catalogObjectGrantService, times(1)).deleteCatalogObjectGrant(DUMMY_BUCKET_NAME,
+                                                                             DUMMY_OBJECT,
+                                                                             "",
+                                                                             DUMMY_GROUP);
     }
 
     @Test
     public void testGetAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup() {
-        catalogObjectGrantController.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_GROUP);
-        verify(catalogObjectGrantService, times(1)).getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_CURRENT_USER, DUMMY_GROUP, DUMMY_OBJECT, DUMMY_BUCKET_NAME);
+        catalogObjectGrantController.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_SESSION_ID,
+                                                                                                   DUMMY_BUCKET_NAME,
+                                                                                                   DUMMY_OBJECT,
+                                                                                                   DUMMY_CURRENT_USER,
+                                                                                                   DUMMY_GROUP);
+        verify(catalogObjectGrantService,
+               times(1)).getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_CURRENT_USER,
+                                                                                       DUMMY_GROUP,
+                                                                                       DUMMY_OBJECT,
+                                                                                       DUMMY_BUCKET_NAME);
     }
 
     @Test
     public void testGetAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket() {
-        catalogObjectGrantController.getAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER);
-        verify(catalogObjectGrantService, times(1)).getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USER, DUMMY_BUCKET_NAME);
+        catalogObjectGrantController.getAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket(DUMMY_SESSION_ID,
+                                                                                                             DUMMY_BUCKET_NAME,
+                                                                                                             DUMMY_CURRENT_USER);
+        verify(catalogObjectGrantService, times(1)).getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USER,
+                                                                                                  DUMMY_BUCKET_NAME);
     }
 }

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantControllerTest.java
@@ -146,7 +146,7 @@ public class CatalogObjectGrantControllerTest {
 
     @Test
     public void testGetAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket() {
-        catalogObjectGrantController.getAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket(DUMMY_SESSION_ID,
+        catalogObjectGrantController.getAllCreatedCatalogObjectGrantsByTheCurrentUserForTheCurrentUserBucket(DUMMY_SESSION_ID,
                                                                                                              DUMMY_BUCKET_NAME,
                                                                                                              DUMMY_CURRENT_USER);
         verify(catalogObjectGrantService, times(1)).getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USER,

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectGrantControllerTest.java
@@ -1,0 +1,82 @@
+package org.ow2.proactive.catalog.rest.controller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.ow2.proactive.catalog.service.BucketGrantService;
+import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
+import org.ow2.proactive.catalog.service.RestApiAccessService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class CatalogObjectGrantControllerTest {
+
+    @InjectMocks
+    CatalogObjectGrantController catalogObjectGrantController;
+
+    @Mock
+    private RestApiAccessService restApiAccessService;
+
+    @Mock
+    private BucketGrantService bucketGrantService;
+
+    @Mock
+    private CatalogObjectGrantService catalogObjectGrantService;
+
+    private final String DUMMY_SESSION_ID = "12345";
+
+    private final String DUMMY_BUCKET_NAME = "dummy-bucket";
+
+    private final String DUMMY_CURRENT_USER = "dummyAdmin";
+
+    private final String DUMMY_USER = "dummyUser";
+
+    private final String DUMMY_GROUP = "dummyGroup";
+
+    private final String DUMMY_OBJECT = "dummyObject";
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(bucketGrantService.isTheUserGrantSufficientForTheCurrentTask(any(),
+                any(),
+                any())).thenReturn(true);
+        when(catalogObjectGrantService.checkInCatalogObjectGrantsIfTheUserOrUserGroupHasAdminRightsOverTheCatalogObject(any(),
+                any(),
+                any())).thenReturn(true);
+        when(catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(any(),
+                any())).thenReturn(true);
+    }
+
+    @Test
+    public void testCreateCatalogObjectGrant() {
+        String DUMMY_ACCESS_TYPE = "admin";
+        catalogObjectGrantController.createCatalogObjectGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, DUMMY_USER, "");
+        verify(catalogObjectGrantService, times(1)).createCatalogObjectGrant(DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, DUMMY_USER, "");
+        catalogObjectGrantController.createCatalogObjectGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
+        verify(catalogObjectGrantService, times(1)).createCatalogObjectGrant(DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
+    }
+
+    @Test
+    public void testDeleteCatalogObjectGrant() {
+        catalogObjectGrantController.deleteCatalogObjectGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_USER, "");
+        verify(catalogObjectGrantService, times(1)).deleteCatalogObjectGrant(DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_USER, "");
+        catalogObjectGrantController.deleteCatalogObjectGrant(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, "", DUMMY_GROUP);
+        verify(catalogObjectGrantService, times(1)).deleteCatalogObjectGrant(DUMMY_BUCKET_NAME, DUMMY_OBJECT, "", DUMMY_GROUP);
+    }
+
+    @Test
+    public void testGetAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup() {
+        catalogObjectGrantController.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_OBJECT, DUMMY_CURRENT_USER, DUMMY_GROUP);
+        verify(catalogObjectGrantService, times(1)).getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_CURRENT_USER, DUMMY_GROUP, DUMMY_OBJECT, DUMMY_BUCKET_NAME);
+    }
+
+    @Test
+    public void testGetAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket() {
+        catalogObjectGrantController.getAllCreatedCatalogObjectGrantsByTheCurrentUSerForTheCurrentUserBucket(DUMMY_SESSION_ID, DUMMY_BUCKET_NAME, DUMMY_CURRENT_USER);
+        verify(catalogObjectGrantService, times(1)).getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USER, DUMMY_BUCKET_NAME);
+    }
+}

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
@@ -1,0 +1,261 @@
+package org.ow2.proactive.catalog.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.ow2.proactive.catalog.dto.BucketGrantMetadata;
+import org.ow2.proactive.catalog.dto.BucketMetadata;
+import org.ow2.proactive.catalog.repository.BucketGrantRepository;
+import org.ow2.proactive.catalog.repository.BucketRepository;
+import org.ow2.proactive.catalog.repository.entity.*;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author ActiveEon Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BucketGrantServiceTest{
+
+    @InjectMocks
+    BucketGrantService bucketGrantService;
+
+    @Mock
+    private BucketRepository bucketRepository;
+
+    @Mock
+    private BucketGrantRepository bucketGrantRepository;
+
+    @Mock
+    private CatalogObjectGrantService catalogObjectGrantService;
+
+    private final String DUMMY_USERNAME = "dummyUser";
+
+    private final String DUMMY_CURRENT_USERNAME = "dummyAdmin";
+
+    private final String DUMMY_GROUP = "dummyGroup";
+
+    private final String DUMMY_BUCKET = "dummyBucket";
+
+    private final String DUMMY_ACCESS_TYPE = "dummyAccessType";
+
+    private final long DUMMY_BUCKET_ID = 1L;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testGetAllAssignedGrantsForUserAndHisGroup() {
+        assertThat(bucketGrantService.getAllAssignedGrantsForUserAndHisGroup(DUMMY_USERNAME, DUMMY_GROUP)).isEmpty();
+        verify(bucketGrantRepository, times(1)).findAllGrantsAssignedToAUsername(DUMMY_USERNAME);
+        verify(bucketGrantRepository, times(1)).findAllGrantsAssignedToAUserGroup(DUMMY_GROUP);
+    }
+
+    @Test
+    public void testUpdateBucketGrantForASpecificUser() {
+        BucketEntity mockedBucket = newMockedBucket(1L);
+        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, mockedBucket);
+        when(bucketGrantRepository.save(any(BucketGrantEntity.class))).thenReturn(bucketGrantEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(bucketGrantRepository.findBucketGrantByUsername(mockedBucket.getId(), DUMMY_USERNAME)).thenReturn(bucketGrantEntity);
+
+        BucketGrantMetadata result = bucketGrantService.updateBucketGrantForASpecificUser(DUMMY_BUCKET, DUMMY_USERNAME, DUMMY_ACCESS_TYPE);
+
+        assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
+        assertEquals("user", result.getGrantee());
+        assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
+        assertEquals(DUMMY_USERNAME, result.getProfiteer());
+        assertEquals(1L, result.getBucketId());
+
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+        verify(bucketGrantRepository, times(1)).findBucketGrantByUsername(DUMMY_BUCKET_ID, DUMMY_USERNAME);
+        verify(bucketGrantRepository, times(1)).save(bucketGrantEntity);
+    }
+
+    @Test
+    public void testUpdateBucketGrantForASpecificUserGroup() {
+        BucketEntity mockedBucket = newMockedBucket(1L);
+        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("group", DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_ACCESS_TYPE, mockedBucket);
+        when(bucketGrantRepository.save(any(BucketGrantEntity.class))).thenReturn(bucketGrantEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(bucketGrantRepository.findBucketGrantByUserGroup(mockedBucket.getId(), DUMMY_GROUP)).thenReturn(bucketGrantEntity);
+
+        BucketGrantMetadata result = bucketGrantService.updateBucketGrantForASpecificUserGroup(DUMMY_BUCKET, DUMMY_GROUP, DUMMY_ACCESS_TYPE);
+
+        assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
+        assertEquals("group", result.getGrantee());
+        assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
+        assertEquals(DUMMY_GROUP, result.getProfiteer());
+        assertEquals(1L, result.getBucketId());
+
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+        verify(bucketGrantRepository, times(1)).findBucketGrantByUserGroup(DUMMY_BUCKET_ID, DUMMY_GROUP);
+        verify(bucketGrantRepository, times(1)).save(bucketGrantEntity);
+    }
+
+    @Test
+    public void testGetAllGrantsCreatedByUsername() {
+        assertThat(bucketGrantService.getAllGrantsCreatedByUsername(DUMMY_USERNAME)).isEmpty();
+        verify(bucketGrantRepository, times(1)).findAllGrantsCreatedByUsername(DUMMY_USERNAME);
+    }
+
+    @Test
+    public void testCreateBucketGrantForUSer() {
+        BucketEntity mockedBucket = newMockedBucket(1L);
+        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, mockedBucket);
+        when(bucketGrantRepository.save(any(BucketGrantEntity.class))).thenReturn(bucketGrantEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+
+        BucketGrantMetadata userGrantMetadata = bucketGrantService.createBucketGrant(DUMMY_BUCKET, DUMMY_CURRENT_USERNAME, DUMMY_ACCESS_TYPE, DUMMY_USERNAME, "");
+
+        assertEquals(DUMMY_ACCESS_TYPE, userGrantMetadata.getAccessType());
+        assertEquals("user", userGrantMetadata.getGrantee());
+        assertEquals(DUMMY_CURRENT_USERNAME, userGrantMetadata.getCreator());
+        assertEquals(DUMMY_USERNAME, userGrantMetadata.getProfiteer());
+        assertEquals(1L, userGrantMetadata.getBucketId());
+
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+        verify(bucketGrantRepository, times(1)).findBucketGrantByUsername(1L, DUMMY_USERNAME);
+        verify(bucketGrantRepository, times(1)).save(bucketGrantEntity);
+    }
+
+    @Test
+    public void testCreateBucketGrantForUserGroup() {
+        BucketEntity mockedBucket = newMockedBucket(1L);
+        BucketGrantEntity groupBucketGrantEntity = new BucketGrantEntity("group", DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_ACCESS_TYPE, mockedBucket);
+        when(bucketGrantRepository.save(any(BucketGrantEntity.class))).thenReturn(groupBucketGrantEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+
+        BucketGrantMetadata userGroupGrantMetadata = bucketGrantService.createBucketGrant(DUMMY_BUCKET, DUMMY_CURRENT_USERNAME, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
+
+        assertEquals(userGroupGrantMetadata.getAccessType(), DUMMY_ACCESS_TYPE);
+        assertEquals(userGroupGrantMetadata.getGrantee(), "group");
+        assertEquals(userGroupGrantMetadata.getCreator(), DUMMY_CURRENT_USERNAME);
+        assertEquals(userGroupGrantMetadata.getProfiteer(), DUMMY_GROUP);
+        assertEquals(userGroupGrantMetadata.getBucketId(), 1L);
+
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+        verify(bucketGrantRepository, times(1)).findBucketGrantByUserGroup(1L, DUMMY_GROUP);
+        verify(bucketGrantRepository, times(1)).save(groupBucketGrantEntity);
+    }
+
+    @Test
+    public void testDeleteBucketGrantForUser() {
+        BucketEntity mockedBucket = newMockedBucket(1L);
+        BucketGrantEntity userBucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, mockedBucket);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(bucketGrantRepository.findBucketGrantByUsername(1L, DUMMY_USERNAME)).thenReturn(userBucketGrantEntity);
+        doNothing().when(bucketGrantRepository).delete(any(BucketGrantEntity.class));
+
+        BucketGrantMetadata userGrantMetadata = bucketGrantService.deleteBucketGrant(DUMMY_BUCKET, DUMMY_USERNAME, "");
+
+        assertEquals(userGrantMetadata.getAccessType(), DUMMY_ACCESS_TYPE);
+        assertEquals(userGrantMetadata.getGrantee(), "user");
+        assertEquals(userGrantMetadata.getCreator(), DUMMY_CURRENT_USERNAME);
+        assertEquals(userGrantMetadata.getProfiteer(), DUMMY_USERNAME);
+        assertEquals(userGrantMetadata.getBucketId(), 1L);
+
+
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+        verify(bucketGrantRepository, times(1)).findBucketGrantByUsername(1L, DUMMY_USERNAME);
+        verify(bucketGrantRepository, times(1)).delete(userBucketGrantEntity);
+    }
+
+    @Test
+    public void testDeleteBucketGrantForGroup() {
+        BucketEntity mockedBucket = newMockedBucket(1L);
+        BucketGrantEntity groupBucketGrantEntity = new BucketGrantEntity("group", DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_ACCESS_TYPE, mockedBucket);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(bucketGrantRepository.findBucketGrantByUserGroup(1L, DUMMY_GROUP)).thenReturn(groupBucketGrantEntity);
+        doNothing().when(bucketGrantRepository).delete(any(BucketGrantEntity.class));
+
+        BucketGrantMetadata groupGrantMetadata = bucketGrantService.deleteBucketGrant(DUMMY_BUCKET, "", DUMMY_GROUP);
+
+        assertEquals(groupGrantMetadata.getAccessType(), DUMMY_ACCESS_TYPE);
+        assertEquals(groupGrantMetadata.getGrantee(), "group");
+        assertEquals(groupGrantMetadata.getCreator(), DUMMY_CURRENT_USERNAME);
+        assertEquals(groupGrantMetadata.getProfiteer(), DUMMY_GROUP);
+        assertEquals(groupGrantMetadata.getBucketId(), 1L);
+
+
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+        verify(bucketGrantRepository, times(1)).findBucketGrantByUserGroup(1L, DUMMY_GROUP);
+        verify(bucketGrantRepository, times(1)).delete(groupBucketGrantEntity);
+    }
+
+    @Test
+    public void testGetBucketsForUserByGrants() {
+        BucketEntity firstMockedBucket = newMockedBucket(1L);
+        BucketEntity secondMockedBucket = newMockedBucket(2L);
+
+        List<Long> idsFromCatalogObjectGrants = new LinkedList<>();
+        idsFromCatalogObjectGrants.add(firstMockedBucket.getId());
+
+        List<Long> idsFromGroupObjectGrants = new LinkedList<>();
+        idsFromGroupObjectGrants.add(secondMockedBucket.getId());
+
+        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, firstMockedBucket);
+
+        List<BucketGrantEntity> mockedBucketGrants = new LinkedList<>();
+        mockedBucketGrants.add(bucketGrantEntity);
+
+        when(catalogObjectGrantService.getAllBucketIdsFromGrantsAssignedToUsername(DUMMY_CURRENT_USERNAME)).thenReturn(idsFromCatalogObjectGrants);
+        when(bucketGrantRepository.findAllGrantsAssignedToAUsername(DUMMY_USERNAME)).thenReturn(mockedBucketGrants);
+        when(bucketGrantRepository.findAllGrantsAssignedToAUserGroup(DUMMY_GROUP)).thenReturn(null);
+        when(catalogObjectGrantService.getAllBucketIdsFromGrantsAssignedToUserGroup(DUMMY_GROUP)).thenReturn(idsFromGroupObjectGrants);
+        when(bucketRepository.findOne(1L)).thenReturn(firstMockedBucket);
+        when(bucketRepository.findOne(2L)).thenReturn(secondMockedBucket);
+
+        List<String> groups = new LinkedList<>();
+        groups.add(DUMMY_GROUP);
+        AuthenticatedUser user = AuthenticatedUser.builder()
+                .name(DUMMY_CURRENT_USERNAME)
+                .groups(groups)
+                .build();
+        List<BucketMetadata> results = bucketGrantService.getBucketsForUserByGrants(user);
+
+        assertEquals(2, results.size());
+        assertTrue(results.contains(new BucketMetadata(firstMockedBucket)));
+        assertTrue(results.contains(new BucketMetadata(secondMockedBucket)));
+    }
+
+    @Test
+    public void testDeleteAllBucketGrants() {
+        BucketEntity mockedBucket = newMockedBucket(1L);
+        BucketGrantEntity userBucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, mockedBucket);
+        List<BucketGrantEntity> mockedBucketGrants = new LinkedList<>();
+        mockedBucketGrants.add(userBucketGrantEntity);
+
+        when(bucketGrantRepository.findAllGrantsByBucket(1L)).thenReturn(mockedBucketGrants);
+        doNothing().when(bucketGrantRepository).delete(any(BucketGrantEntity.class));
+        doNothing().when(catalogObjectGrantService).deleteAllCatalogObjectsGrantsAssignedToABucket(1L);
+
+        bucketGrantService.deleteAllBucketGrants(mockedBucket.getId());
+
+        verify(bucketGrantRepository, times(1)).findAllGrantsByBucket(mockedBucket.getId());
+        verify(bucketGrantRepository, times(1)).delete(mockedBucketGrants);
+        verify(catalogObjectGrantService, times(1)).deleteAllCatalogObjectsGrantsAssignedToABucket(mockedBucket.getId());
+    }
+
+    private BucketEntity newMockedBucket(Long id) {
+        BucketEntity mockedBucket = mock(BucketEntity.class);
+        when(mockedBucket.getId()).thenReturn(id);
+        when(mockedBucket.getBucketName()).thenReturn(DUMMY_BUCKET);
+        return mockedBucket;
+    }
+
+}

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
@@ -110,7 +110,7 @@ public class BucketGrantServiceTest{
     @Test
     public void testGetAllGrantsCreatedByUsername() {
         assertThat(bucketGrantService.getAllGrantsCreatedByUsername(DUMMY_USERNAME)).isEmpty();
-        verify(bucketGrantRepository, times(1)).findAllGrantsCreatedByUsername(DUMMY_USERNAME);
+        verify(bucketGrantRepository, times(1)).findBucketGrantEntitiesByCreator(DUMMY_USERNAME);
     }
 
     @Test
@@ -240,13 +240,13 @@ public class BucketGrantServiceTest{
         List<BucketGrantEntity> mockedBucketGrants = new LinkedList<>();
         mockedBucketGrants.add(userBucketGrantEntity);
 
-        when(bucketGrantRepository.findAllGrantsByBucket(1L)).thenReturn(mockedBucketGrants);
+        when(bucketGrantRepository.findBucketGrantEntitiesByBucketEntityId(1L)).thenReturn(mockedBucketGrants);
         doNothing().when(bucketGrantRepository).delete(any(BucketGrantEntity.class));
         doNothing().when(catalogObjectGrantService).deleteAllCatalogObjectsGrantsAssignedToABucket(1L);
 
         bucketGrantService.deleteAllBucketGrants(mockedBucket.getId());
 
-        verify(bucketGrantRepository, times(1)).findAllGrantsByBucket(mockedBucket.getId());
+        verify(bucketGrantRepository, times(1)).findBucketGrantEntitiesByBucketEntityId(mockedBucket.getId());
         verify(bucketGrantRepository, times(1)).delete(mockedBucketGrants);
         verify(catalogObjectGrantService, times(1)).deleteAllCatalogObjectsGrantsAssignedToABucket(mockedBucket.getId());
     }

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
@@ -1,4 +1,38 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
 package org.ow2.proactive.catalog.service;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.LinkedList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -14,20 +48,12 @@ import org.ow2.proactive.catalog.repository.BucketRepository;
 import org.ow2.proactive.catalog.repository.entity.*;
 import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
 
 /**
  * @author ActiveEon Team
  */
 @RunWith(MockitoJUnitRunner.class)
-public class BucketGrantServiceTest{
+public class BucketGrantServiceTest {
 
     @InjectMocks
     BucketGrantService bucketGrantService;
@@ -68,12 +94,19 @@ public class BucketGrantServiceTest{
     @Test
     public void testUpdateBucketGrantForASpecificUser() {
         BucketEntity mockedBucket = newMockedBucket(1L);
-        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, mockedBucket);
+        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user",
+                                                                    DUMMY_CURRENT_USERNAME,
+                                                                    DUMMY_USERNAME,
+                                                                    DUMMY_ACCESS_TYPE,
+                                                                    mockedBucket);
         when(bucketGrantRepository.save(any(BucketGrantEntity.class))).thenReturn(bucketGrantEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(bucketGrantRepository.findBucketGrantByUsername(mockedBucket.getId(), DUMMY_USERNAME)).thenReturn(bucketGrantEntity);
+        when(bucketGrantRepository.findBucketGrantByUsername(mockedBucket.getId(),
+                                                             DUMMY_USERNAME)).thenReturn(bucketGrantEntity);
 
-        BucketGrantMetadata result = bucketGrantService.updateBucketGrantForASpecificUser(DUMMY_BUCKET, DUMMY_USERNAME, DUMMY_ACCESS_TYPE);
+        BucketGrantMetadata result = bucketGrantService.updateBucketGrantForASpecificUser(DUMMY_BUCKET,
+                                                                                          DUMMY_USERNAME,
+                                                                                          DUMMY_ACCESS_TYPE);
 
         assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
         assertEquals("user", result.getGrantee());
@@ -89,12 +122,19 @@ public class BucketGrantServiceTest{
     @Test
     public void testUpdateBucketGrantForASpecificUserGroup() {
         BucketEntity mockedBucket = newMockedBucket(1L);
-        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("group", DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_ACCESS_TYPE, mockedBucket);
+        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("group",
+                                                                    DUMMY_CURRENT_USERNAME,
+                                                                    DUMMY_GROUP,
+                                                                    DUMMY_ACCESS_TYPE,
+                                                                    mockedBucket);
         when(bucketGrantRepository.save(any(BucketGrantEntity.class))).thenReturn(bucketGrantEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(bucketGrantRepository.findBucketGrantByUserGroup(mockedBucket.getId(), DUMMY_GROUP)).thenReturn(bucketGrantEntity);
+        when(bucketGrantRepository.findBucketGrantByUserGroup(mockedBucket.getId(),
+                                                              DUMMY_GROUP)).thenReturn(bucketGrantEntity);
 
-        BucketGrantMetadata result = bucketGrantService.updateBucketGrantForASpecificUserGroup(DUMMY_BUCKET, DUMMY_GROUP, DUMMY_ACCESS_TYPE);
+        BucketGrantMetadata result = bucketGrantService.updateBucketGrantForASpecificUserGroup(DUMMY_BUCKET,
+                                                                                               DUMMY_GROUP,
+                                                                                               DUMMY_ACCESS_TYPE);
 
         assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
         assertEquals("group", result.getGrantee());
@@ -116,11 +156,19 @@ public class BucketGrantServiceTest{
     @Test
     public void testCreateBucketGrantForUSer() {
         BucketEntity mockedBucket = newMockedBucket(1L);
-        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, mockedBucket);
+        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user",
+                                                                    DUMMY_CURRENT_USERNAME,
+                                                                    DUMMY_USERNAME,
+                                                                    DUMMY_ACCESS_TYPE,
+                                                                    mockedBucket);
         when(bucketGrantRepository.save(any(BucketGrantEntity.class))).thenReturn(bucketGrantEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
 
-        BucketGrantMetadata userGrantMetadata = bucketGrantService.createBucketGrant(DUMMY_BUCKET, DUMMY_CURRENT_USERNAME, DUMMY_ACCESS_TYPE, DUMMY_USERNAME, "");
+        BucketGrantMetadata userGrantMetadata = bucketGrantService.createBucketGrant(DUMMY_BUCKET,
+                                                                                     DUMMY_CURRENT_USERNAME,
+                                                                                     DUMMY_ACCESS_TYPE,
+                                                                                     DUMMY_USERNAME,
+                                                                                     "");
 
         assertEquals(DUMMY_ACCESS_TYPE, userGrantMetadata.getAccessType());
         assertEquals("user", userGrantMetadata.getGrantee());
@@ -136,11 +184,19 @@ public class BucketGrantServiceTest{
     @Test
     public void testCreateBucketGrantForUserGroup() {
         BucketEntity mockedBucket = newMockedBucket(1L);
-        BucketGrantEntity groupBucketGrantEntity = new BucketGrantEntity("group", DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_ACCESS_TYPE, mockedBucket);
+        BucketGrantEntity groupBucketGrantEntity = new BucketGrantEntity("group",
+                                                                         DUMMY_CURRENT_USERNAME,
+                                                                         DUMMY_GROUP,
+                                                                         DUMMY_ACCESS_TYPE,
+                                                                         mockedBucket);
         when(bucketGrantRepository.save(any(BucketGrantEntity.class))).thenReturn(groupBucketGrantEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
 
-        BucketGrantMetadata userGroupGrantMetadata = bucketGrantService.createBucketGrant(DUMMY_BUCKET, DUMMY_CURRENT_USERNAME, DUMMY_ACCESS_TYPE, "", DUMMY_GROUP);
+        BucketGrantMetadata userGroupGrantMetadata = bucketGrantService.createBucketGrant(DUMMY_BUCKET,
+                                                                                          DUMMY_CURRENT_USERNAME,
+                                                                                          DUMMY_ACCESS_TYPE,
+                                                                                          "",
+                                                                                          DUMMY_GROUP);
 
         assertEquals(userGroupGrantMetadata.getAccessType(), DUMMY_ACCESS_TYPE);
         assertEquals(userGroupGrantMetadata.getGrantee(), "group");
@@ -156,7 +212,11 @@ public class BucketGrantServiceTest{
     @Test
     public void testDeleteBucketGrantForUser() {
         BucketEntity mockedBucket = newMockedBucket(1L);
-        BucketGrantEntity userBucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, mockedBucket);
+        BucketGrantEntity userBucketGrantEntity = new BucketGrantEntity("user",
+                                                                        DUMMY_CURRENT_USERNAME,
+                                                                        DUMMY_USERNAME,
+                                                                        DUMMY_ACCESS_TYPE,
+                                                                        mockedBucket);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
         when(bucketGrantRepository.findBucketGrantByUsername(1L, DUMMY_USERNAME)).thenReturn(userBucketGrantEntity);
         doNothing().when(bucketGrantRepository).delete(any(BucketGrantEntity.class));
@@ -169,7 +229,6 @@ public class BucketGrantServiceTest{
         assertEquals(userGrantMetadata.getProfiteer(), DUMMY_USERNAME);
         assertEquals(userGrantMetadata.getBucketId(), 1L);
 
-
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
         verify(bucketGrantRepository, times(1)).findBucketGrantByUsername(1L, DUMMY_USERNAME);
         verify(bucketGrantRepository, times(1)).delete(userBucketGrantEntity);
@@ -178,7 +237,11 @@ public class BucketGrantServiceTest{
     @Test
     public void testDeleteBucketGrantForGroup() {
         BucketEntity mockedBucket = newMockedBucket(1L);
-        BucketGrantEntity groupBucketGrantEntity = new BucketGrantEntity("group", DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_ACCESS_TYPE, mockedBucket);
+        BucketGrantEntity groupBucketGrantEntity = new BucketGrantEntity("group",
+                                                                         DUMMY_CURRENT_USERNAME,
+                                                                         DUMMY_GROUP,
+                                                                         DUMMY_ACCESS_TYPE,
+                                                                         mockedBucket);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
         when(bucketGrantRepository.findBucketGrantByUserGroup(1L, DUMMY_GROUP)).thenReturn(groupBucketGrantEntity);
         doNothing().when(bucketGrantRepository).delete(any(BucketGrantEntity.class));
@@ -190,7 +253,6 @@ public class BucketGrantServiceTest{
         assertEquals(groupGrantMetadata.getCreator(), DUMMY_CURRENT_USERNAME);
         assertEquals(groupGrantMetadata.getProfiteer(), DUMMY_GROUP);
         assertEquals(groupGrantMetadata.getBucketId(), 1L);
-
 
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
         verify(bucketGrantRepository, times(1)).findBucketGrantByUserGroup(1L, DUMMY_GROUP);
@@ -208,7 +270,11 @@ public class BucketGrantServiceTest{
         List<Long> idsFromGroupObjectGrants = new LinkedList<>();
         idsFromGroupObjectGrants.add(secondMockedBucket.getId());
 
-        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, firstMockedBucket);
+        BucketGrantEntity bucketGrantEntity = new BucketGrantEntity("user",
+                                                                    DUMMY_CURRENT_USERNAME,
+                                                                    DUMMY_USERNAME,
+                                                                    DUMMY_ACCESS_TYPE,
+                                                                    firstMockedBucket);
 
         List<BucketGrantEntity> mockedBucketGrants = new LinkedList<>();
         mockedBucketGrants.add(bucketGrantEntity);
@@ -222,10 +288,7 @@ public class BucketGrantServiceTest{
 
         List<String> groups = new LinkedList<>();
         groups.add(DUMMY_GROUP);
-        AuthenticatedUser user = AuthenticatedUser.builder()
-                .name(DUMMY_CURRENT_USERNAME)
-                .groups(groups)
-                .build();
+        AuthenticatedUser user = AuthenticatedUser.builder().name(DUMMY_CURRENT_USERNAME).groups(groups).build();
         List<BucketMetadata> results = bucketGrantService.getBucketsForUserByGrants(user);
 
         assertEquals(2, results.size());
@@ -236,7 +299,11 @@ public class BucketGrantServiceTest{
     @Test
     public void testDeleteAllBucketGrants() {
         BucketEntity mockedBucket = newMockedBucket(1L);
-        BucketGrantEntity userBucketGrantEntity = new BucketGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, mockedBucket);
+        BucketGrantEntity userBucketGrantEntity = new BucketGrantEntity("user",
+                                                                        DUMMY_CURRENT_USERNAME,
+                                                                        DUMMY_USERNAME,
+                                                                        DUMMY_ACCESS_TYPE,
+                                                                        mockedBucket);
         List<BucketGrantEntity> mockedBucketGrants = new LinkedList<>();
         mockedBucketGrants.add(userBucketGrantEntity);
 
@@ -248,7 +315,8 @@ public class BucketGrantServiceTest{
 
         verify(bucketGrantRepository, times(1)).findBucketGrantEntitiesByBucketEntityId(mockedBucket.getId());
         verify(bucketGrantRepository, times(1)).delete(mockedBucketGrants);
-        verify(catalogObjectGrantService, times(1)).deleteAllCatalogObjectsGrantsAssignedToABucket(mockedBucket.getId());
+        verify(catalogObjectGrantService,
+               times(1)).deleteAllCatalogObjectsGrantsAssignedToABucket(mockedBucket.getId());
     }
 
     private BucketEntity newMockedBucket(Long id) {

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
@@ -86,9 +86,11 @@ public class BucketGrantServiceTest {
 
     @Test
     public void testGetAllAssignedGrantsForUserAndHisGroup() {
-        assertThat(bucketGrantService.getAllAssignedGrantsForUserAndHisGroup(DUMMY_USERNAME, DUMMY_GROUP)).isEmpty();
+        List<String> userGroups = new LinkedList<>();
+        userGroups.add(DUMMY_GROUP);
+        assertThat(bucketGrantService.getAllAssignedGrantsForUserAndHisGroups(DUMMY_USERNAME, userGroups)).isEmpty();
         verify(bucketGrantRepository, times(1)).findAllGrantsAssignedToAUsername(DUMMY_USERNAME);
-        verify(bucketGrantRepository, times(1)).findAllGrantsAssignedToAUserGroup(DUMMY_GROUP);
+        verify(bucketGrantRepository, times(1)).findAllGrantsAssignedToTheUserGroups(userGroups);
     }
 
     @Test
@@ -109,9 +111,9 @@ public class BucketGrantServiceTest {
                                                                                           DUMMY_ACCESS_TYPE);
 
         assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
-        assertEquals("user", result.getGrantee());
+        assertEquals("user", result.getGranteeType());
         assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
-        assertEquals(DUMMY_USERNAME, result.getProfiteer());
+        assertEquals(DUMMY_USERNAME, result.getGrantee());
         assertEquals(1L, result.getBucketId());
 
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
@@ -137,9 +139,9 @@ public class BucketGrantServiceTest {
                                                                                                DUMMY_ACCESS_TYPE);
 
         assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
-        assertEquals("group", result.getGrantee());
+        assertEquals("group", result.getGranteeType());
         assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
-        assertEquals(DUMMY_GROUP, result.getProfiteer());
+        assertEquals(DUMMY_GROUP, result.getGrantee());
         assertEquals(1L, result.getBucketId());
 
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
@@ -171,9 +173,9 @@ public class BucketGrantServiceTest {
                                                                                      "");
 
         assertEquals(DUMMY_ACCESS_TYPE, userGrantMetadata.getAccessType());
-        assertEquals("user", userGrantMetadata.getGrantee());
+        assertEquals("user", userGrantMetadata.getGranteeType());
         assertEquals(DUMMY_CURRENT_USERNAME, userGrantMetadata.getCreator());
-        assertEquals(DUMMY_USERNAME, userGrantMetadata.getProfiteer());
+        assertEquals(DUMMY_USERNAME, userGrantMetadata.getGrantee());
         assertEquals(1L, userGrantMetadata.getBucketId());
 
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
@@ -199,9 +201,9 @@ public class BucketGrantServiceTest {
                                                                                           DUMMY_GROUP);
 
         assertEquals(userGroupGrantMetadata.getAccessType(), DUMMY_ACCESS_TYPE);
-        assertEquals(userGroupGrantMetadata.getGrantee(), "group");
+        assertEquals(userGroupGrantMetadata.getGranteeType(), "group");
         assertEquals(userGroupGrantMetadata.getCreator(), DUMMY_CURRENT_USERNAME);
-        assertEquals(userGroupGrantMetadata.getProfiteer(), DUMMY_GROUP);
+        assertEquals(userGroupGrantMetadata.getGrantee(), DUMMY_GROUP);
         assertEquals(userGroupGrantMetadata.getBucketId(), 1L);
 
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
@@ -224,9 +226,9 @@ public class BucketGrantServiceTest {
         BucketGrantMetadata userGrantMetadata = bucketGrantService.deleteBucketGrant(DUMMY_BUCKET, DUMMY_USERNAME, "");
 
         assertEquals(userGrantMetadata.getAccessType(), DUMMY_ACCESS_TYPE);
-        assertEquals(userGrantMetadata.getGrantee(), "user");
+        assertEquals(userGrantMetadata.getGranteeType(), "user");
         assertEquals(userGrantMetadata.getCreator(), DUMMY_CURRENT_USERNAME);
-        assertEquals(userGrantMetadata.getProfiteer(), DUMMY_USERNAME);
+        assertEquals(userGrantMetadata.getGrantee(), DUMMY_USERNAME);
         assertEquals(userGrantMetadata.getBucketId(), 1L);
 
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
@@ -249,9 +251,9 @@ public class BucketGrantServiceTest {
         BucketGrantMetadata groupGrantMetadata = bucketGrantService.deleteBucketGrant(DUMMY_BUCKET, "", DUMMY_GROUP);
 
         assertEquals(groupGrantMetadata.getAccessType(), DUMMY_ACCESS_TYPE);
-        assertEquals(groupGrantMetadata.getGrantee(), "group");
+        assertEquals(groupGrantMetadata.getGranteeType(), "group");
         assertEquals(groupGrantMetadata.getCreator(), DUMMY_CURRENT_USERNAME);
-        assertEquals(groupGrantMetadata.getProfiteer(), DUMMY_GROUP);
+        assertEquals(groupGrantMetadata.getGrantee(), DUMMY_GROUP);
         assertEquals(groupGrantMetadata.getBucketId(), 1L);
 
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
@@ -261,6 +263,9 @@ public class BucketGrantServiceTest {
 
     @Test
     public void testGetBucketsForUserByGrants() {
+        List<String> userGroups = new LinkedList<>();
+        userGroups.add(DUMMY_GROUP);
+
         BucketEntity firstMockedBucket = newMockedBucket(1L);
         BucketEntity secondMockedBucket = newMockedBucket(2L);
 
@@ -281,8 +286,8 @@ public class BucketGrantServiceTest {
 
         when(catalogObjectGrantService.getAllBucketIdsFromGrantsAssignedToUsername(DUMMY_CURRENT_USERNAME)).thenReturn(idsFromCatalogObjectGrants);
         when(bucketGrantRepository.findAllGrantsAssignedToAUsername(DUMMY_USERNAME)).thenReturn(mockedBucketGrants);
-        when(bucketGrantRepository.findAllGrantsAssignedToAUserGroup(DUMMY_GROUP)).thenReturn(null);
-        when(catalogObjectGrantService.getAllBucketIdsFromGrantsAssignedToUserGroup(DUMMY_GROUP)).thenReturn(idsFromGroupObjectGrants);
+        when(bucketGrantRepository.findAllGrantsAssignedToTheUserGroups(userGroups)).thenReturn(null);
+        when(catalogObjectGrantService.getAllBucketIdsFromGrantsAssignedToUserGroup(userGroups)).thenReturn(idsFromGroupObjectGrants);
         when(bucketRepository.findOne(1L)).thenReturn(firstMockedBucket);
         when(bucketRepository.findOne(2L)).thenReturn(secondMockedBucket);
 

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketServiceTest.java
@@ -83,6 +83,9 @@ public class BucketServiceTest {
     @Mock
     private BucketNameValidator bucketNameValidator;
 
+    @Mock
+    private BucketGrantService bucketGrantService;
+
     @Test
     public void testThatEmptyListIsReturnedIfListAndKindAreNull() {
         assertThat(bucketService.listBuckets((List<String>) null, null, null, null)).isEmpty();

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectGrantServiceTest.java
@@ -1,4 +1,36 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
 package org.ow2.proactive.catalog.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.LinkedList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -13,12 +45,6 @@ import org.ow2.proactive.catalog.repository.CatalogObjectGrantRepository;
 import org.ow2.proactive.catalog.repository.CatalogObjectRevisionRepository;
 import org.ow2.proactive.catalog.repository.entity.*;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
 
 /**
  * @author ActiveEon Team
@@ -63,16 +89,33 @@ public class CatalogObjectGrantServiceTest {
         dummyBucketsName.add(DUMMY_BUCKET);
         BucketEntity mockedBucket = newMockedBucket();
         CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
-        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
-        CatalogObjectGrantEntity dbCatalogObjectGrantEntity = new CatalogObjectGrantEntity("user", "admin", "user", "admin", dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                         DUMMY_CURRENT_USERNAME,
+                                                                                         DUMMY_USERNAME,
+                                                                                         DUMMY_ACCESS_TYPE,
+                                                                                         dummyCatalogObjectRevisionEntity,
+                                                                                         mockedBucket);
+        CatalogObjectGrantEntity dbCatalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                           "admin",
+                                                                                           "user",
+                                                                                           "admin",
+                                                                                           dummyCatalogObjectRevisionEntity,
+                                                                                           mockedBucket);
 
         when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
-                DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
+                                                                                    DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(dbCatalogObjectGrantEntity);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(),
+                                                                           anyString(),
+                                                                           anyLong())).thenReturn(dbCatalogObjectGrantEntity);
         when(catalogObjectGrantRepository.save(any(CatalogObjectGrantEntity.class))).thenReturn(catalogObjectGrantEntity);
 
-        CatalogObjectGrantMetadata result = catalogObjectGrantService.createCatalogObjectGrant(DUMMY_BUCKET, DUMMY_OBJECT, DUMMY_CURRENT_USERNAME, DUMMY_ACCESS_TYPE, DUMMY_USERNAME, "");
+        CatalogObjectGrantMetadata result = catalogObjectGrantService.createCatalogObjectGrant(DUMMY_BUCKET,
+                                                                                               DUMMY_OBJECT,
+                                                                                               DUMMY_CURRENT_USERNAME,
+                                                                                               DUMMY_ACCESS_TYPE,
+                                                                                               DUMMY_USERNAME,
+                                                                                               "");
 
         assertEquals("user", result.getGrantee());
         assertEquals(DUMMY_USERNAME, result.getProfiteer());
@@ -81,8 +124,11 @@ public class CatalogObjectGrantServiceTest {
         assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
         assertEquals(CATALOG_OBJECT_ID, result.getCatalogObjectId());
 
-        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName, DUMMY_OBJECT);
-        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID, DUMMY_USERNAME, BUCKET_ID);
+        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
+                                                                                                 DUMMY_OBJECT);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID,
+                                                                                        DUMMY_USERNAME,
+                                                                                        BUCKET_ID);
         verify(catalogObjectGrantRepository, times(1)).save(catalogObjectGrantEntity);
     }
 
@@ -92,15 +138,25 @@ public class CatalogObjectGrantServiceTest {
         dummyBucketsName.add(DUMMY_BUCKET);
         BucketEntity mockedBucket = newMockedBucket();
         CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
-        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                         DUMMY_CURRENT_USERNAME,
+                                                                                         DUMMY_USERNAME,
+                                                                                         DUMMY_ACCESS_TYPE,
+                                                                                         dummyCatalogObjectRevisionEntity,
+                                                                                         mockedBucket);
 
         when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
-                DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
+                                                                                    DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(catalogObjectGrantEntity);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(),
+                                                                           anyString(),
+                                                                           anyLong())).thenReturn(catalogObjectGrantEntity);
         doNothing().when(catalogObjectGrantRepository).delete(any(CatalogObjectGrantEntity.class));
 
-        CatalogObjectGrantMetadata result = catalogObjectGrantService.deleteCatalogObjectGrant(DUMMY_BUCKET, DUMMY_OBJECT, DUMMY_USERNAME, "");
+        CatalogObjectGrantMetadata result = catalogObjectGrantService.deleteCatalogObjectGrant(DUMMY_BUCKET,
+                                                                                               DUMMY_OBJECT,
+                                                                                               DUMMY_USERNAME,
+                                                                                               "");
 
         assertEquals("user", result.getGrantee());
         assertEquals(DUMMY_USERNAME, result.getProfiteer());
@@ -109,8 +165,11 @@ public class CatalogObjectGrantServiceTest {
         assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
         assertEquals(CATALOG_OBJECT_ID, result.getCatalogObjectId());
 
-        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName, DUMMY_OBJECT);
-        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID, DUMMY_USERNAME, BUCKET_ID);
+        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
+                                                                                                 DUMMY_OBJECT);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID,
+                                                                                        DUMMY_USERNAME,
+                                                                                        BUCKET_ID);
         verify(catalogObjectGrantRepository, times(1)).delete(catalogObjectGrantEntity);
     }
 
@@ -120,15 +179,26 @@ public class CatalogObjectGrantServiceTest {
         dummyBucketsName.add(DUMMY_BUCKET);
         BucketEntity mockedBucket = newMockedBucket();
         CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
-        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                         DUMMY_CURRENT_USERNAME,
+                                                                                         DUMMY_USERNAME,
+                                                                                         DUMMY_ACCESS_TYPE,
+                                                                                         dummyCatalogObjectRevisionEntity,
+                                                                                         mockedBucket);
 
         when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
-                DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
+                                                                                    DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(catalogObjectGrantEntity);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(),
+                                                                           anyString(),
+                                                                           anyLong())).thenReturn(catalogObjectGrantEntity);
         when(catalogObjectGrantRepository.save(any(CatalogObjectGrantEntity.class))).thenReturn(catalogObjectGrantEntity);
 
-        CatalogObjectGrantMetadata result = catalogObjectGrantService.updateCatalogObjectGrant(DUMMY_USERNAME, "", DUMMY_OBJECT, DUMMY_BUCKET, DUMMY_ACCESS_TYPE);
+        CatalogObjectGrantMetadata result = catalogObjectGrantService.updateCatalogObjectGrant(DUMMY_USERNAME,
+                                                                                               "",
+                                                                                               DUMMY_OBJECT,
+                                                                                               DUMMY_BUCKET,
+                                                                                               DUMMY_ACCESS_TYPE);
 
         assertEquals("user", result.getGrantee());
         assertEquals(DUMMY_USERNAME, result.getProfiteer());
@@ -137,8 +207,11 @@ public class CatalogObjectGrantServiceTest {
         assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
         assertEquals(CATALOG_OBJECT_ID, result.getCatalogObjectId());
 
-        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName, DUMMY_OBJECT);
-        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID, DUMMY_USERNAME, BUCKET_ID);
+        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
+                                                                                                 DUMMY_OBJECT);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID,
+                                                                                        DUMMY_USERNAME,
+                                                                                        BUCKET_ID);
         verify(catalogObjectGrantRepository, times(1)).save(catalogObjectGrantEntity);
     }
 
@@ -148,19 +221,31 @@ public class CatalogObjectGrantServiceTest {
         dummyBucketsName.add(DUMMY_BUCKET);
         BucketEntity mockedBucket = newMockedBucket();
         CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
-        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                         DUMMY_CURRENT_USERNAME,
+                                                                                         DUMMY_USERNAME,
+                                                                                         DUMMY_ACCESS_TYPE,
+                                                                                         dummyCatalogObjectRevisionEntity,
+                                                                                         mockedBucket);
 
         List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
         dbUserObjectGrants.add(catalogObjectGrantEntity);
 
         when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
-                DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
+                                                                                    DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUsername(DUMMY_CURRENT_USERNAME, CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUsername(DUMMY_CURRENT_USERNAME,
+                                                                                        CATALOG_OBJECT_ID,
+                                                                                        BUCKET_ID)).thenReturn(dbUserObjectGrants);
         String DUMMY_GROUP = "dummyGroup";
-        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUserGroup(DUMMY_GROUP, CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(new LinkedList<>());
+        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUserGroup(DUMMY_GROUP,
+                                                                                         CATALOG_OBJECT_ID,
+                                                                                         BUCKET_ID)).thenReturn(new LinkedList<>());
 
-        List<CatalogObjectGrantMetadata> results = catalogObjectGrantService.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_OBJECT, DUMMY_BUCKET);
+        List<CatalogObjectGrantMetadata> results = catalogObjectGrantService.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_CURRENT_USERNAME,
+                                                                                                                                           DUMMY_GROUP,
+                                                                                                                                           DUMMY_OBJECT,
+                                                                                                                                           DUMMY_BUCKET);
 
         assertEquals(1, results.size());
         assertEquals("user", results.get(0).getGrantee());
@@ -170,9 +255,15 @@ public class CatalogObjectGrantServiceTest {
         assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
         assertEquals(CATALOG_OBJECT_ID, results.get(0).getCatalogObjectId());
 
-        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName, DUMMY_OBJECT);
-        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToAUsername(DUMMY_CURRENT_USERNAME, CATALOG_OBJECT_ID, BUCKET_ID);
-        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToAUserGroup(DUMMY_GROUP, CATALOG_OBJECT_ID, BUCKET_ID);
+        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
+                                                                                                 DUMMY_OBJECT);
+        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToAUsername(
+                                                                                                     DUMMY_CURRENT_USERNAME,
+                                                                                                     CATALOG_OBJECT_ID,
+                                                                                                     BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToAUserGroup(DUMMY_GROUP,
+                                                                                                      CATALOG_OBJECT_ID,
+                                                                                                      BUCKET_ID);
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
     }
 
@@ -180,14 +271,21 @@ public class CatalogObjectGrantServiceTest {
     public void testGetAllCreatedCatalogObjectGrantsForThisBucket() {
         BucketEntity mockedBucket = newMockedBucket();
         CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
-        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                         DUMMY_CURRENT_USERNAME,
+                                                                                         DUMMY_USERNAME,
+                                                                                         DUMMY_ACCESS_TYPE,
+                                                                                         dummyCatalogObjectRevisionEntity,
+                                                                                         mockedBucket);
 
         List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
         dbUserObjectGrants.add(catalogObjectGrantEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(DUMMY_CURRENT_USERNAME, BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(DUMMY_CURRENT_USERNAME,
+                                                                                                   BUCKET_ID)).thenReturn(dbUserObjectGrants);
 
-        List<CatalogObjectGrantMetadata> results = catalogObjectGrantService.getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USERNAME, DUMMY_BUCKET);
+        List<CatalogObjectGrantMetadata> results = catalogObjectGrantService.getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USERNAME,
+                                                                                                                           DUMMY_BUCKET);
 
         assertEquals(1, results.size());
         assertEquals("user", results.get(0).getGrantee());
@@ -197,7 +295,8 @@ public class CatalogObjectGrantServiceTest {
         assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
         assertEquals(CATALOG_OBJECT_ID, results.get(0).getCatalogObjectId());
 
-        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(DUMMY_CURRENT_USERNAME, BUCKET_ID);
+        verify(catalogObjectGrantRepository,
+               times(1)).findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(DUMMY_CURRENT_USERNAME, BUCKET_ID);
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
 
     }
@@ -206,7 +305,12 @@ public class CatalogObjectGrantServiceTest {
     public void testFindAllCatalogObjectGrantsAssignedToABucket() {
         BucketEntity mockedBucket = newMockedBucket();
         CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
-        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                         DUMMY_CURRENT_USERNAME,
+                                                                                         DUMMY_USERNAME,
+                                                                                         DUMMY_ACCESS_TYPE,
+                                                                                         dummyCatalogObjectRevisionEntity,
+                                                                                         mockedBucket);
         List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
         dbUserObjectGrants.add(catalogObjectGrantEntity);
 
@@ -231,7 +335,12 @@ public class CatalogObjectGrantServiceTest {
     public void testDeleteAllCatalogObjectsGrantsAssignedToABucket() {
         BucketEntity mockedBucket = newMockedBucket();
         CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
-        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                         DUMMY_CURRENT_USERNAME,
+                                                                                         DUMMY_USERNAME,
+                                                                                         DUMMY_ACCESS_TYPE,
+                                                                                         dummyCatalogObjectRevisionEntity,
+                                                                                         mockedBucket);
         List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
         dbUserObjectGrants.add(catalogObjectGrantEntity);
 
@@ -248,16 +357,24 @@ public class CatalogObjectGrantServiceTest {
     public void testDeleteAllCatalogObjectGrants() {
         BucketEntity mockedBucket = newMockedBucket();
         CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
-        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user",
+                                                                                         DUMMY_CURRENT_USERNAME,
+                                                                                         DUMMY_USERNAME,
+                                                                                         DUMMY_ACCESS_TYPE,
+                                                                                         dummyCatalogObjectRevisionEntity,
+                                                                                         mockedBucket);
         List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
         dbUserObjectGrants.add(catalogObjectGrantEntity);
 
-        when(catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(CATALOG_OBJECT_ID,
+                                                                                                                         BUCKET_ID)).thenReturn(dbUserObjectGrants);
         doNothing().when(catalogObjectGrantRepository).delete(any(CatalogObjectGrantEntity.class));
 
         catalogObjectGrantService.deleteAllCatalogObjectGrants(BUCKET_ID, CATALOG_OBJECT_ID);
 
-        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(CATALOG_OBJECT_ID, BUCKET_ID);
+        verify(catalogObjectGrantRepository,
+               times(1)).findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(CATALOG_OBJECT_ID,
+                                                                                                        BUCKET_ID);
         verify(catalogObjectGrantRepository, times(1)).delete(dbUserObjectGrants);
     }
 

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectGrantServiceTest.java
@@ -117,8 +117,8 @@ public class CatalogObjectGrantServiceTest {
                                                                                                DUMMY_USERNAME,
                                                                                                "");
 
-        assertEquals("user", result.getGrantee());
-        assertEquals(DUMMY_USERNAME, result.getProfiteer());
+        assertEquals("user", result.getGranteeType());
+        assertEquals(DUMMY_USERNAME, result.getGrantee());
         assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
         assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
         assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
@@ -158,8 +158,8 @@ public class CatalogObjectGrantServiceTest {
                                                                                                DUMMY_USERNAME,
                                                                                                "");
 
-        assertEquals("user", result.getGrantee());
-        assertEquals(DUMMY_USERNAME, result.getProfiteer());
+        assertEquals("user", result.getGranteeType());
+        assertEquals(DUMMY_USERNAME, result.getGrantee());
         assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
         assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
         assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
@@ -200,8 +200,8 @@ public class CatalogObjectGrantServiceTest {
                                                                                                DUMMY_BUCKET,
                                                                                                DUMMY_ACCESS_TYPE);
 
-        assertEquals("user", result.getGrantee());
-        assertEquals(DUMMY_USERNAME, result.getProfiteer());
+        assertEquals("user", result.getGranteeType());
+        assertEquals(DUMMY_USERNAME, result.getGrantee());
         assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
         assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
         assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
@@ -248,8 +248,8 @@ public class CatalogObjectGrantServiceTest {
                                                                                                                                            DUMMY_BUCKET);
 
         assertEquals(1, results.size());
-        assertEquals("user", results.get(0).getGrantee());
-        assertEquals(DUMMY_USERNAME, results.get(0).getProfiteer());
+        assertEquals("user", results.get(0).getGranteeType());
+        assertEquals(DUMMY_USERNAME, results.get(0).getGrantee());
         assertEquals(DUMMY_ACCESS_TYPE, results.get(0).getAccessType());
         assertEquals(DUMMY_CURRENT_USERNAME, results.get(0).getCreator());
         assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
@@ -288,8 +288,8 @@ public class CatalogObjectGrantServiceTest {
                                                                                                                            DUMMY_BUCKET);
 
         assertEquals(1, results.size());
-        assertEquals("user", results.get(0).getGrantee());
-        assertEquals(DUMMY_USERNAME, results.get(0).getProfiteer());
+        assertEquals("user", results.get(0).getGranteeType());
+        assertEquals(DUMMY_USERNAME, results.get(0).getGrantee());
         assertEquals(DUMMY_ACCESS_TYPE, results.get(0).getAccessType());
         assertEquals(DUMMY_CURRENT_USERNAME, results.get(0).getCreator());
         assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
@@ -320,8 +320,8 @@ public class CatalogObjectGrantServiceTest {
         List<CatalogObjectGrantMetadata> results = catalogObjectGrantService.findAllCatalogObjectGrantsAssignedToABucket(DUMMY_BUCKET);
 
         assertEquals(1, results.size());
-        assertEquals("user", results.get(0).getGrantee());
-        assertEquals(DUMMY_USERNAME, results.get(0).getProfiteer());
+        assertEquals("user", results.get(0).getGranteeType());
+        assertEquals(DUMMY_USERNAME, results.get(0).getGrantee());
         assertEquals(DUMMY_ACCESS_TYPE, results.get(0).getAccessType());
         assertEquals(DUMMY_CURRENT_USERNAME, results.get(0).getCreator());
         assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectGrantServiceTest.java
@@ -1,0 +1,276 @@
+package org.ow2.proactive.catalog.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetaData;
+import org.ow2.proactive.catalog.repository.BucketRepository;
+import org.ow2.proactive.catalog.repository.CatalogObjectGrantRepository;
+import org.ow2.proactive.catalog.repository.CatalogObjectRevisionRepository;
+import org.ow2.proactive.catalog.repository.entity.*;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author ActiveEon Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CatalogObjectGrantServiceTest {
+
+    @InjectMocks
+    CatalogObjectGrantService catalogObjectGrantService;
+
+    @Mock
+    private CatalogObjectGrantRepository catalogObjectGrantRepository;
+
+    @Mock
+    private BucketRepository bucketRepository;
+
+    @Mock
+    private CatalogObjectRevisionRepository catalogObjectRevisionRepository;
+
+    private final String DUMMY_USERNAME = "dummyUser";
+
+    private final String DUMMY_CURRENT_USERNAME = "dummyAdmin";
+
+    private final String DUMMY_BUCKET = "dummyBucket";
+
+    private final String DUMMY_OBJECT = "dummyObject";
+
+    private final String DUMMY_ACCESS_TYPE = "dummyAccessType";
+
+    private final long BUCKET_ID = 1L;
+
+    private final long CATALOG_OBJECT_ID = 1L;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testCreateCatalogObjectGrant() {
+        List<String> dummyBucketsName = new LinkedList<>();
+        dummyBucketsName.add(DUMMY_BUCKET);
+        BucketEntity mockedBucket = newMockedBucket();
+        CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        CatalogObjectGrantEntity dbCatalogObjectGrantEntity = new CatalogObjectGrantEntity("user", "admin", "user", "admin", dummyCatalogObjectRevisionEntity, mockedBucket);
+
+        when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
+                DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(dbCatalogObjectGrantEntity);
+        when(catalogObjectGrantRepository.save(any(CatalogObjectGrantEntity.class))).thenReturn(catalogObjectGrantEntity);
+
+        CatalogObjectGrantMetaData result = catalogObjectGrantService.createCatalogObjectGrant(DUMMY_BUCKET, DUMMY_OBJECT, DUMMY_CURRENT_USERNAME, DUMMY_ACCESS_TYPE, DUMMY_USERNAME, "");
+
+        assertEquals("user", result.getGrantee());
+        assertEquals(DUMMY_USERNAME, result.getProfiteer());
+        assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
+        assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
+        assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
+        assertEquals(CATALOG_OBJECT_ID, result.getCatalogObjectId());
+
+        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName, DUMMY_OBJECT);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID, DUMMY_USERNAME, BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).save(catalogObjectGrantEntity);
+    }
+
+    @Test
+    public void testDeleteCatalogObjectGrant() {
+        List<String> dummyBucketsName = new LinkedList<>();
+        dummyBucketsName.add(DUMMY_BUCKET);
+        BucketEntity mockedBucket = newMockedBucket();
+        CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+
+        when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
+                DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(catalogObjectGrantEntity);
+        doNothing().when(catalogObjectGrantRepository).delete(any(CatalogObjectGrantEntity.class));
+
+        CatalogObjectGrantMetaData result = catalogObjectGrantService.deleteCatalogObjectGrant(DUMMY_BUCKET, DUMMY_OBJECT, DUMMY_USERNAME, "");
+
+        assertEquals("user", result.getGrantee());
+        assertEquals(DUMMY_USERNAME, result.getProfiteer());
+        assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
+        assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
+        assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
+        assertEquals(CATALOG_OBJECT_ID, result.getCatalogObjectId());
+
+        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName, DUMMY_OBJECT);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID, DUMMY_USERNAME, BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).delete(catalogObjectGrantEntity);
+    }
+
+    @Test
+    public void testUpdateCatalogObjectGrant() {
+        List<String> dummyBucketsName = new LinkedList<>();
+        dummyBucketsName.add(DUMMY_BUCKET);
+        BucketEntity mockedBucket = newMockedBucket();
+        CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+
+        when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
+                DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(catalogObjectGrantEntity);
+        when(catalogObjectGrantRepository.save(any(CatalogObjectGrantEntity.class))).thenReturn(catalogObjectGrantEntity);
+
+        CatalogObjectGrantMetaData result = catalogObjectGrantService.updateCatalogObjectGrant(DUMMY_USERNAME, "", DUMMY_OBJECT, DUMMY_BUCKET, DUMMY_ACCESS_TYPE);
+
+        assertEquals("user", result.getGrantee());
+        assertEquals(DUMMY_USERNAME, result.getProfiteer());
+        assertEquals(DUMMY_ACCESS_TYPE, result.getAccessType());
+        assertEquals(DUMMY_CURRENT_USERNAME, result.getCreator());
+        assertEquals(BUCKET_ID, result.getCatalogObjectBucketId());
+        assertEquals(CATALOG_OBJECT_ID, result.getCatalogObjectId());
+
+        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName, DUMMY_OBJECT);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantByUsername(CATALOG_OBJECT_ID, DUMMY_USERNAME, BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).save(catalogObjectGrantEntity);
+    }
+
+    @Test
+    public void testGetAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup() {
+        List<String> dummyBucketsName = new LinkedList<>();
+        dummyBucketsName.add(DUMMY_BUCKET);
+        BucketEntity mockedBucket = newMockedBucket();
+        CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+
+        List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
+        dbUserObjectGrants.add(catalogObjectGrantEntity);
+
+        when(catalogObjectRevisionRepository.findDefaultCatalogObjectByNameInBucket(dummyBucketsName,
+                DUMMY_OBJECT)).thenReturn(dummyCatalogObjectRevisionEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUsername(DUMMY_CURRENT_USERNAME, CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        String DUMMY_GROUP = "dummyGroup";
+        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUserGroup(DUMMY_GROUP, CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(new LinkedList<>());
+
+        List<CatalogObjectGrantMetaData> results = catalogObjectGrantService.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_OBJECT, DUMMY_BUCKET);
+
+        assertEquals(1, results.size());
+        assertEquals("user", results.get(0).getGrantee());
+        assertEquals(DUMMY_USERNAME, results.get(0).getProfiteer());
+        assertEquals(DUMMY_ACCESS_TYPE, results.get(0).getAccessType());
+        assertEquals(DUMMY_CURRENT_USERNAME, results.get(0).getCreator());
+        assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
+        assertEquals(CATALOG_OBJECT_ID, results.get(0).getCatalogObjectId());
+
+        verify(catalogObjectRevisionRepository, times(1)).findDefaultCatalogObjectByNameInBucket(dummyBucketsName, DUMMY_OBJECT);
+        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToAUsername(DUMMY_CURRENT_USERNAME, CATALOG_OBJECT_ID, BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToAUserGroup(DUMMY_GROUP, CATALOG_OBJECT_ID, BUCKET_ID);
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+    }
+
+    @Test
+    public void testGetAllCreatedCatalogObjectGrantsForThisBucket() {
+        BucketEntity mockedBucket = newMockedBucket();
+        CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+
+        List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
+        dbUserObjectGrants.add(catalogObjectGrantEntity);
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(catalogObjectGrantRepository.findAllCatalogObjectsGrantsCreatedByUsernameInASpecificBucket(DUMMY_CURRENT_USERNAME, BUCKET_ID)).thenReturn(dbUserObjectGrants);
+
+        List<CatalogObjectGrantMetaData> results = catalogObjectGrantService.getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USERNAME, DUMMY_BUCKET);
+
+        assertEquals(1, results.size());
+        assertEquals("user", results.get(0).getGrantee());
+        assertEquals(DUMMY_USERNAME, results.get(0).getProfiteer());
+        assertEquals(DUMMY_ACCESS_TYPE, results.get(0).getAccessType());
+        assertEquals(DUMMY_CURRENT_USERNAME, results.get(0).getCreator());
+        assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
+        assertEquals(CATALOG_OBJECT_ID, results.get(0).getCatalogObjectId());
+
+        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectsGrantsCreatedByUsernameInASpecificBucket(DUMMY_CURRENT_USERNAME, BUCKET_ID);
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+
+    }
+
+    @Test
+    public void testFindAllCatalogObjectGrantsAssignedToABucket() {
+        BucketEntity mockedBucket = newMockedBucket();
+        CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
+        dbUserObjectGrants.add(catalogObjectGrantEntity);
+
+        when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
+        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToABucket(BUCKET_ID)).thenReturn(dbUserObjectGrants);
+
+        List<CatalogObjectGrantMetaData> results = catalogObjectGrantService.findAllCatalogObjectGrantsAssignedToABucket(DUMMY_BUCKET);
+
+        assertEquals(1, results.size());
+        assertEquals("user", results.get(0).getGrantee());
+        assertEquals(DUMMY_USERNAME, results.get(0).getProfiteer());
+        assertEquals(DUMMY_ACCESS_TYPE, results.get(0).getAccessType());
+        assertEquals(DUMMY_CURRENT_USERNAME, results.get(0).getCreator());
+        assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
+        assertEquals(CATALOG_OBJECT_ID, results.get(0).getCatalogObjectId());
+
+        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToABucket(BUCKET_ID);
+        verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
+    }
+
+    @Test
+    public void testDeleteAllCatalogObjectsGrantsAssignedToABucket() {
+        BucketEntity mockedBucket = newMockedBucket();
+        CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
+        dbUserObjectGrants.add(catalogObjectGrantEntity);
+
+        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToABucket(BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        doNothing().when(catalogObjectGrantRepository).delete(any(CatalogObjectGrantEntity.class));
+
+        catalogObjectGrantService.deleteAllCatalogObjectsGrantsAssignedToABucket(BUCKET_ID);
+
+        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToABucket(BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).delete(dbUserObjectGrants);
+    }
+
+    @Test
+    public void testDeleteAllCatalogObjectGrants() {
+        BucketEntity mockedBucket = newMockedBucket();
+        CatalogObjectRevisionEntity dummyCatalogObjectRevisionEntity = newCatalogObjectRevisionEntity();
+        CatalogObjectGrantEntity catalogObjectGrantEntity = new CatalogObjectGrantEntity("user", DUMMY_CURRENT_USERNAME, DUMMY_USERNAME, DUMMY_ACCESS_TYPE, dummyCatalogObjectRevisionEntity, mockedBucket);
+        List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
+        dbUserObjectGrants.add(catalogObjectGrantEntity);
+
+        when(catalogObjectGrantRepository.findAllGrantsByCatalogObjectIdInBucket(CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        doNothing().when(catalogObjectGrantRepository).delete(any(CatalogObjectGrantEntity.class));
+
+        catalogObjectGrantService.deleteAllCatalogObjectGrants(BUCKET_ID, CATALOG_OBJECT_ID);
+
+        verify(catalogObjectGrantRepository, times(1)).findAllGrantsByCatalogObjectIdInBucket(CATALOG_OBJECT_ID, BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).delete(dbUserObjectGrants);
+    }
+
+    private CatalogObjectRevisionEntity newCatalogObjectRevisionEntity() {
+        CatalogObjectRevisionEntity catalogObjectRevisionEntity = mock(CatalogObjectRevisionEntity.class);
+        when(catalogObjectRevisionEntity.getId()).thenReturn(CATALOG_OBJECT_ID);
+        return catalogObjectRevisionEntity;
+    }
+
+    private BucketEntity newMockedBucket() {
+        BucketEntity mockedBucket = mock(BucketEntity.class);
+        when(mockedBucket.getId()).thenReturn(BUCKET_ID);
+        when(mockedBucket.getBucketName()).thenReturn(DUMMY_BUCKET);
+        return mockedBucket;
+    }
+}

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectGrantServiceTest.java
@@ -7,7 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetaData;
+import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetadata;
 import org.ow2.proactive.catalog.repository.BucketRepository;
 import org.ow2.proactive.catalog.repository.CatalogObjectGrantRepository;
 import org.ow2.proactive.catalog.repository.CatalogObjectRevisionRepository;
@@ -72,7 +72,7 @@ public class CatalogObjectGrantServiceTest {
         when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(dbCatalogObjectGrantEntity);
         when(catalogObjectGrantRepository.save(any(CatalogObjectGrantEntity.class))).thenReturn(catalogObjectGrantEntity);
 
-        CatalogObjectGrantMetaData result = catalogObjectGrantService.createCatalogObjectGrant(DUMMY_BUCKET, DUMMY_OBJECT, DUMMY_CURRENT_USERNAME, DUMMY_ACCESS_TYPE, DUMMY_USERNAME, "");
+        CatalogObjectGrantMetadata result = catalogObjectGrantService.createCatalogObjectGrant(DUMMY_BUCKET, DUMMY_OBJECT, DUMMY_CURRENT_USERNAME, DUMMY_ACCESS_TYPE, DUMMY_USERNAME, "");
 
         assertEquals("user", result.getGrantee());
         assertEquals(DUMMY_USERNAME, result.getProfiteer());
@@ -100,7 +100,7 @@ public class CatalogObjectGrantServiceTest {
         when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(catalogObjectGrantEntity);
         doNothing().when(catalogObjectGrantRepository).delete(any(CatalogObjectGrantEntity.class));
 
-        CatalogObjectGrantMetaData result = catalogObjectGrantService.deleteCatalogObjectGrant(DUMMY_BUCKET, DUMMY_OBJECT, DUMMY_USERNAME, "");
+        CatalogObjectGrantMetadata result = catalogObjectGrantService.deleteCatalogObjectGrant(DUMMY_BUCKET, DUMMY_OBJECT, DUMMY_USERNAME, "");
 
         assertEquals("user", result.getGrantee());
         assertEquals(DUMMY_USERNAME, result.getProfiteer());
@@ -128,7 +128,7 @@ public class CatalogObjectGrantServiceTest {
         when(catalogObjectGrantRepository.findCatalogObjectGrantByUsername(anyLong(), anyString(), anyLong())).thenReturn(catalogObjectGrantEntity);
         when(catalogObjectGrantRepository.save(any(CatalogObjectGrantEntity.class))).thenReturn(catalogObjectGrantEntity);
 
-        CatalogObjectGrantMetaData result = catalogObjectGrantService.updateCatalogObjectGrant(DUMMY_USERNAME, "", DUMMY_OBJECT, DUMMY_BUCKET, DUMMY_ACCESS_TYPE);
+        CatalogObjectGrantMetadata result = catalogObjectGrantService.updateCatalogObjectGrant(DUMMY_USERNAME, "", DUMMY_OBJECT, DUMMY_BUCKET, DUMMY_ACCESS_TYPE);
 
         assertEquals("user", result.getGrantee());
         assertEquals(DUMMY_USERNAME, result.getProfiteer());
@@ -160,7 +160,7 @@ public class CatalogObjectGrantServiceTest {
         String DUMMY_GROUP = "dummyGroup";
         when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToAUserGroup(DUMMY_GROUP, CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(new LinkedList<>());
 
-        List<CatalogObjectGrantMetaData> results = catalogObjectGrantService.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_OBJECT, DUMMY_BUCKET);
+        List<CatalogObjectGrantMetadata> results = catalogObjectGrantService.getAllAssignedCatalogObjectGrantsForTheCurrentUserAndHisGroup(DUMMY_CURRENT_USERNAME, DUMMY_GROUP, DUMMY_OBJECT, DUMMY_BUCKET);
 
         assertEquals(1, results.size());
         assertEquals("user", results.get(0).getGrantee());
@@ -185,9 +185,9 @@ public class CatalogObjectGrantServiceTest {
         List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
         dbUserObjectGrants.add(catalogObjectGrantEntity);
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(catalogObjectGrantRepository.findAllCatalogObjectsGrantsCreatedByUsernameInASpecificBucket(DUMMY_CURRENT_USERNAME, BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(DUMMY_CURRENT_USERNAME, BUCKET_ID)).thenReturn(dbUserObjectGrants);
 
-        List<CatalogObjectGrantMetaData> results = catalogObjectGrantService.getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USERNAME, DUMMY_BUCKET);
+        List<CatalogObjectGrantMetadata> results = catalogObjectGrantService.getAllCreatedCatalogObjectGrantsForThisBucket(DUMMY_CURRENT_USERNAME, DUMMY_BUCKET);
 
         assertEquals(1, results.size());
         assertEquals("user", results.get(0).getGrantee());
@@ -197,7 +197,7 @@ public class CatalogObjectGrantServiceTest {
         assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
         assertEquals(CATALOG_OBJECT_ID, results.get(0).getCatalogObjectId());
 
-        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectsGrantsCreatedByUsernameInASpecificBucket(DUMMY_CURRENT_USERNAME, BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantEntitiesByCreatorAndBucketEntityId(DUMMY_CURRENT_USERNAME, BUCKET_ID);
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
 
     }
@@ -211,9 +211,9 @@ public class CatalogObjectGrantServiceTest {
         dbUserObjectGrants.add(catalogObjectGrantEntity);
 
         when(bucketRepository.findOneByBucketName(DUMMY_BUCKET)).thenReturn(mockedBucket);
-        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToABucket(BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByBucketEntityId(BUCKET_ID)).thenReturn(dbUserObjectGrants);
 
-        List<CatalogObjectGrantMetaData> results = catalogObjectGrantService.findAllCatalogObjectGrantsAssignedToABucket(DUMMY_BUCKET);
+        List<CatalogObjectGrantMetadata> results = catalogObjectGrantService.findAllCatalogObjectGrantsAssignedToABucket(DUMMY_BUCKET);
 
         assertEquals(1, results.size());
         assertEquals("user", results.get(0).getGrantee());
@@ -223,7 +223,7 @@ public class CatalogObjectGrantServiceTest {
         assertEquals(BUCKET_ID, results.get(0).getCatalogObjectBucketId());
         assertEquals(CATALOG_OBJECT_ID, results.get(0).getCatalogObjectId());
 
-        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToABucket(BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantEntitiesByBucketEntityId(BUCKET_ID);
         verify(bucketRepository, times(1)).findOneByBucketName(DUMMY_BUCKET);
     }
 
@@ -235,12 +235,12 @@ public class CatalogObjectGrantServiceTest {
         List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
         dbUserObjectGrants.add(catalogObjectGrantEntity);
 
-        when(catalogObjectGrantRepository.findAllCatalogObjectGrantsAssignedToABucket(BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByBucketEntityId(BUCKET_ID)).thenReturn(dbUserObjectGrants);
         doNothing().when(catalogObjectGrantRepository).delete(any(CatalogObjectGrantEntity.class));
 
         catalogObjectGrantService.deleteAllCatalogObjectsGrantsAssignedToABucket(BUCKET_ID);
 
-        verify(catalogObjectGrantRepository, times(1)).findAllCatalogObjectGrantsAssignedToABucket(BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantEntitiesByBucketEntityId(BUCKET_ID);
         verify(catalogObjectGrantRepository, times(1)).delete(dbUserObjectGrants);
     }
 
@@ -252,12 +252,12 @@ public class CatalogObjectGrantServiceTest {
         List<CatalogObjectGrantEntity> dbUserObjectGrants = new LinkedList<>();
         dbUserObjectGrants.add(catalogObjectGrantEntity);
 
-        when(catalogObjectGrantRepository.findAllGrantsByCatalogObjectIdInBucket(CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(dbUserObjectGrants);
+        when(catalogObjectGrantRepository.findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(CATALOG_OBJECT_ID, BUCKET_ID)).thenReturn(dbUserObjectGrants);
         doNothing().when(catalogObjectGrantRepository).delete(any(CatalogObjectGrantEntity.class));
 
         catalogObjectGrantService.deleteAllCatalogObjectGrants(BUCKET_ID, CATALOG_OBJECT_ID);
 
-        verify(catalogObjectGrantRepository, times(1)).findAllGrantsByCatalogObjectIdInBucket(CATALOG_OBJECT_ID, BUCKET_ID);
+        verify(catalogObjectGrantRepository, times(1)).findCatalogObjectGrantEntitiesByCatalogObjectRevisionEntityIdAndBucketEntityId(CATALOG_OBJECT_ID, BUCKET_ID);
         verify(catalogObjectGrantRepository, times(1)).delete(dbUserObjectGrants);
     }
 


### PR DESCRIPTION
The following features were added in this PR:

1. DB Entities for Buckets' and Objects' grants
2. REST controllers and services for all grants mainly to do: create, edit, delete and get
3. Updated the existing catalog controllers and services to handle the new grant features
4. Added functional tests for the Grant controllers and services

The following tasks remains to develop while I'm handling this PR reviews:

1. Bug fix regarding the number of objects in grant buckets
2. Fix the current integration tests
3. Write new integration tests to handle the new grant features