### PR TITLE
Fix the issue regarding a bucket with noAccess grant

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/CatalogObjectGrantMetadata.java
@@ -68,6 +68,20 @@ public class CatalogObjectGrantMetadata extends ResourceSupport {
     @JsonProperty
     private final String bucketName;
 
+    public CatalogObjectGrantMetadata(String granteeType, String creator, String grantee, String accessType,
+            int priority, CatalogObjectID catalogObjectId, String catalogObjectName, long catalogObjectBucketId,
+            String bucketName) {
+        this.granteeType = granteeType;
+        this.creator = creator;
+        this.grantee = grantee;
+        this.accessType = accessType;
+        this.priority = priority;
+        this.catalogObjectId = catalogObjectId;
+        this.catalogObjectName = catalogObjectName;
+        this.catalogObjectBucketId = catalogObjectBucketId;
+        this.bucketName = bucketName;
+    }
+
     public CatalogObjectGrantMetadata(CatalogObjectGrantEntity catalogObjectGrantEntity) {
         this.granteeType = catalogObjectGrantEntity.getGranteeType();
         this.creator = catalogObjectGrantEntity.getCreator();

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -441,7 +441,7 @@ public class CatalogObjectController {
             }
             // This function remove all objects that the user has a noAccess grant over them
             if (sessionIdRequired) {
-                grantRightsService.removeAllObjectsWithNoAccessGrant(user, metadataList);
+                grantRightsService.removeAllObjectsWithNoAccessGrant(user, metadataList, bucketName);
             }
 
             for (CatalogObjectMetadata catalogObject : metadataList) {

--- a/src/main/java/org/ow2/proactive/catalog/service/GrantRightsService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GrantRightsService.java
@@ -426,7 +426,8 @@ public class GrantRightsService {
      * @param user authenticated user
      * @param metadataList list of catalog objects in a bucket
      */
-    public void removeAllObjectsWithNoAccessGrant(AuthenticatedUser user, List<CatalogObjectMetadata> metadataList) {
+    public void removeAllObjectsWithNoAccessGrant(AuthenticatedUser user, List<CatalogObjectMetadata> metadataList,
+            String bucketName) {
         // List of inaccessible object for the user
         List<CatalogObjectGrantMetadata> userGrantsWithNoAccessRights = catalogObjectGrantService.getUserNoAccessGrant(user);
         // List of accessible object for the user
@@ -509,6 +510,7 @@ public class GrantRightsService {
                                                                                                      grant.getGranteeType()
                                                                                                           .equals("group")))
                                                                                    .collect(Collectors.toList());
+            userBucketNoAccessGrants.removeIf(grant -> !grant.getBucketName().equals(bucketName));
             if (!userBucketNoAccessGrants.isEmpty()) {
                 List<String> objectsNotToRemove = userGrantsWithPositiveGrants.stream()
                                                                               .filter(grant -> grant.getGranteeType()

--- a/src/test/java/org/ow2/proactive/catalog/service/GrantRightServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/GrantRightServiceTest.java
@@ -1,0 +1,158 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.ow2.proactive.catalog.util.AccessType.noAccess;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.ow2.proactive.catalog.dto.BucketGrantMetadata;
+import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetadata;
+import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
+import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class GrantRightServiceTest {
+
+    @InjectMocks
+    GrantRightsService grantRightsService;
+
+    @Mock
+    CatalogObjectGrantService catalogObjectGrantService;
+
+    @Mock
+    BucketGrantService bucketGrantService;
+
+    private final String bucketName = "test-bucket";
+
+    @Test
+    public void testRemoveAllObjectsWithNoAccessGrantWhenTheUserHasNotANoAccessGrantForTheCurrentBucket() {
+        List<String> userGroups = new LinkedList<>();
+        userGroups.add("user");
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.builder().name("user").groups(userGroups).build();
+        when(catalogObjectGrantService.getUserNoAccessGrant(authenticatedUser)).thenReturn(new LinkedList<>());
+        when(catalogObjectGrantService.getAllGrantsAssignedToAUser(authenticatedUser)).thenReturn(new LinkedList<>());
+
+        List<BucketGrantMetadata> bucketGrantMetadataList = new LinkedList<>();
+        bucketGrantMetadataList.add(createBucketGrantMetadata("user", noAccess.toString(), "bucket"));
+        bucketGrantMetadataList.add(createBucketGrantMetadata("user1", noAccess.toString(), "bucket"));
+
+        when(bucketGrantService.getAllNoAccessGrants()).thenReturn(bucketGrantMetadataList);
+
+        List<CatalogObjectMetadata> metadataList = new LinkedList<>();
+
+        metadataList.add(createCatalogObject(bucketName, "object1"));
+        metadataList.add(createCatalogObject(bucketName, "object2"));
+        metadataList.add(createCatalogObject(bucketName, "object3"));
+
+        grantRightsService.removeAllObjectsWithNoAccessGrant(authenticatedUser, metadataList, bucketName);
+
+        verify(catalogObjectGrantService, times(1)).getUserNoAccessGrant(authenticatedUser);
+        verify(bucketGrantService, times(1)).getAllNoAccessGrants();
+
+        assertEquals(3, metadataList.size());
+    }
+
+    @Test
+    public void testRemoveAllObjectsWithNoAccessGrantWhenTheUserHasANoAccessGrantForTheCurrentBucket() {
+        List<String> userGroups = new LinkedList<>();
+        userGroups.add("user");
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.builder().name("user").groups(userGroups).build();
+        when(catalogObjectGrantService.getUserNoAccessGrant(authenticatedUser)).thenReturn(new LinkedList<>());
+        when(catalogObjectGrantService.getAllGrantsAssignedToAUser(authenticatedUser)).thenReturn(new LinkedList<>());
+
+        List<BucketGrantMetadata> bucketGrantMetadataList = new LinkedList<>();
+        bucketGrantMetadataList.add(createBucketGrantMetadata("user", noAccess.toString(), bucketName));
+
+        when(bucketGrantService.getAllNoAccessGrants()).thenReturn(bucketGrantMetadataList);
+
+        List<CatalogObjectMetadata> metadataList = new LinkedList<>();
+
+        metadataList.add(createCatalogObject(bucketName, "object1"));
+        metadataList.add(createCatalogObject(bucketName, "object2"));
+        metadataList.add(createCatalogObject(bucketName, "object3"));
+
+        grantRightsService.removeAllObjectsWithNoAccessGrant(authenticatedUser, metadataList, bucketName);
+
+        verify(catalogObjectGrantService, times(1)).getUserNoAccessGrant(authenticatedUser);
+        verify(bucketGrantService, times(1)).getAllNoAccessGrants();
+
+        assertEquals(0, metadataList.size());
+    }
+
+    @Test
+    public void testRemoveAllObjectsWhenTheUserHasANoAccessGrantForTheCurrentBucketButKeepObjectsWithPositiveGrants() {
+        List<String> userGroups = new LinkedList<>();
+        userGroups.add("user");
+        AuthenticatedUser authenticatedUser = AuthenticatedUser.builder().name("user").groups(userGroups).build();
+        when(catalogObjectGrantService.getUserNoAccessGrant(authenticatedUser)).thenReturn(new LinkedList<>());
+
+        CatalogObjectGrantMetadata catalogObjectGrantMetadata = createObjectGrantMetadata(bucketName, "object1");
+        List<CatalogObjectGrantMetadata> objectGrants = new LinkedList<>();
+        objectGrants.add(catalogObjectGrantMetadata);
+
+        when(catalogObjectGrantService.getAllGrantsAssignedToAUser(authenticatedUser)).thenReturn(objectGrants);
+
+        List<BucketGrantMetadata> bucketGrantMetadataList = new LinkedList<>();
+        bucketGrantMetadataList.add(createBucketGrantMetadata("user", noAccess.toString(), bucketName));
+
+        when(bucketGrantService.getAllNoAccessGrants()).thenReturn(bucketGrantMetadataList);
+
+        List<CatalogObjectMetadata> metadataList = new LinkedList<>();
+
+        metadataList.add(createCatalogObject(bucketName, "object1"));
+        metadataList.add(createCatalogObject(bucketName, "object2"));
+        metadataList.add(createCatalogObject(bucketName, "object3"));
+
+        grantRightsService.removeAllObjectsWithNoAccessGrant(authenticatedUser, metadataList, bucketName);
+
+        verify(catalogObjectGrantService, times(1)).getUserNoAccessGrant(authenticatedUser);
+        verify(bucketGrantService, times(1)).getAllNoAccessGrants();
+
+        assertEquals(1, metadataList.size());
+    }
+
+    private BucketGrantMetadata createBucketGrantMetadata(String userName, String accessType, String bucketName) {
+        return new BucketGrantMetadata(userName, "admin", "user", accessType, 0, 1L, bucketName);
+    }
+
+    private CatalogObjectMetadata createCatalogObject(String bucketName, String objectName) {
+        return new CatalogObjectMetadata(bucketName, objectName, "", "", "", 0, "", "", new LinkedList<>(), "");
+    }
+
+    private CatalogObjectGrantMetadata createObjectGrantMetadata(String bucketName, String objectName) {
+        return new CatalogObjectGrantMetadata("user", "admin", "user", "read", 0, null, objectName, 0, bucketName);
+    }
+}


### PR DESCRIPTION
The issue that is solved in this PR was that when there is a bucket grant for a user with noAccess rights, all other buckets' objects are not shown.