### PR TITLE
Improve the performance of list catalog objects in a bucket request by reducing the redundant DB queries

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/dto/BucketMetadata.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/BucketMetadata.java
@@ -48,7 +48,7 @@ public class BucketMetadata extends ResourceSupport {
     private final String name;
 
     @JsonProperty
-    private final int objectCount;
+    private int objectCount;
 
     @JsonProperty
     private String rights;
@@ -83,6 +83,10 @@ public class BucketMetadata extends ResourceSupport {
 
     public String getName() {
         return name;
+    }
+
+    public void setObjectCount(int objectCount) {
+        this.objectCount = objectCount;
     }
 
     public void setRights(String rights) {

--- a/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
@@ -47,6 +47,12 @@ public interface BucketGrantRepository extends JpaRepository<BucketGrantEntity, 
     @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.bucketEntity.id = ?1 AND bge.grantee = ?2 AND bge.granteeType='group'")
     BucketGrantEntity findBucketGrantByUserGroup(long bucketId, String userGroup);
 
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee = ?1 AND bge.granteeType='user'")
+    List<BucketGrantEntity> findAllBucketsGrantsByUsername(String username);
+
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee in ?1 AND bge.granteeType='group'")
+    List<BucketGrantEntity> findAllBucketsGrantsByUserGroup(List<String> userGroup);
+
     @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee = ?1 And bge.granteeType='user' AND bge.accessType<>'noAccess'")
     List<BucketGrantEntity> findAllAccessibleBucketGrantsAssignedToAUsername(String username);
 

--- a/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/BucketGrantRepository.java
@@ -57,11 +57,18 @@ public interface BucketGrantRepository extends JpaRepository<BucketGrantEntity, 
     List<BucketGrantEntity> findAllAccessibleBucketGrantsAssignedToAUsernameInsideABucket(String username,
             long bucketId);
 
-    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee in ?1 And bge.granteeType='group' AND bge.bucketEntity.id=?2 AND bge.accessType<>'noAccess'")
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee in ?1 AND bge.bucketEntity.id=?2 And bge.granteeType='group' AND bge.accessType<>'noAccess'")
     List<BucketGrantEntity> findAllAccessibleBucketGrantsAssignedToTheUserGroupsInsideABucket(List<String> userGroup,
             long bucketId);
 
     @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.accessType='noAccess'")
     List<BucketGrantEntity> findAllBucketGrantsWithNoAccessRight();
+
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee = ?1 AND bge.bucketEntity.id=?2 And bge.granteeType='user' AND bge.accessType='noAccess'")
+    List<BucketGrantEntity> findBucketGrantsAssignedToAUsernameWithNoAccessRight(String username, long bucketId);
+
+    @Query(value = "SELECT bge FROM BucketGrantEntity bge WHERE bge.grantee in ?1 AND bge.bucketEntity.id=?2 And bge.granteeType='group' AND bge.accessType='noAccess'")
+    List<BucketGrantEntity> findBucketGrantsAssignedToUserGroupsWithNoAccessRight(List<String> userGroup,
+            long bucketId);
 
 }

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
@@ -83,8 +83,14 @@ public interface CatalogObjectGrantRepository extends JpaRepository<CatalogObjec
             findAllObjectGrantsWithNoAccessRightsAndAssignedToAUserGroup(List<String> userGroups);
 
     @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.grantee = ?1 AND coge.granteeType='user' AND coge.accessType<>'noAccess'")
-    List<CatalogObjectGrantEntity> findAllObjectGrantsAssignedToAUser(String username);
+    List<CatalogObjectGrantEntity> findAllAccessibleObjectGrantsAssignedToAUser(String username);
 
     @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.grantee in ?1 AND coge.granteeType='group' AND coge.accessType<>'noAccess'")
+    List<CatalogObjectGrantEntity> findAllAccessibleObjectGrantsAssignedToUserGroups(List<String> userGroup);
+
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.grantee = ?1 AND coge.granteeType='user'")
+    List<CatalogObjectGrantEntity> findAllObjectGrantsAssignedToAUser(String username);
+
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.grantee in ?1 AND coge.granteeType='group'")
     List<CatalogObjectGrantEntity> findAllObjectGrantsAssignedToUserGroups(List<String> userGroup);
 }

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectGrantRepository.java
@@ -47,6 +47,13 @@ public interface CatalogObjectGrantRepository extends JpaRepository<CatalogObjec
     @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObject.bucket.id = ?1")
     List<CatalogObjectGrantEntity> findCatalogObjectGrantEntitiesByBucketEntityId(long bucketId);
 
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObject.bucket.id = ?1 AND coge.grantee = ?2 And coge.granteeType='user'")
+    List<CatalogObjectGrantEntity> findCatalogObjectsGrantsInABucketAssignedToAUser(long bucketId, String username);
+
+    @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObject.bucket.id = ?1 AND coge.grantee in ?2 And coge.granteeType='group'")
+    List<CatalogObjectGrantEntity> findCatalogObjectsGrantsInABucketAssignedToAUserGroup(long bucketId,
+            List<String> userGroup);
+
     //TODO to test
     @Query(value = "SELECT coge FROM CatalogObjectGrantEntity coge WHERE coge.catalogObject.bucket.bucketName = ?1 AND  coge.catalogObject.id.name = ?2 AND coge.accessType<>'noAccess'")
     List<CatalogObjectGrantEntity> findAllGrantsAssignedToAnObjectInsideABucket(String bucketName,

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
@@ -221,6 +221,7 @@ public class BucketController {
             for (BucketMetadata data : listBucket) {
                 String bucketGrantAccessType = grantRightsService.getResultingAccessTypeFromUserGrantsForBucketOperations(user,
                                                                                                                           data.getName());
+                //TODO try to improve performance
                 int objectCount = bucketGrantService.getTheNumberOfAccessibleObjectsInTheBucket(user, data);
                 BucketMetadata metadata = new BucketMetadata(data.getName(), data.getOwner(), objectCount);
                 metadata.setRights(bucketGrantAccessType);

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectController.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -138,7 +139,6 @@ public class CatalogObjectController {
                                                                      write.toString())) {
                 throw new BucketGrantAccessException(bucketName);
             }
-
         }
 
         String userName = "";
@@ -368,23 +368,24 @@ public class CatalogObjectController {
 
         // Check Grants
         AuthenticatedUser user = null;
-        List<CatalogObjectGrantMetadata> catalogObjectGrants = new LinkedList<>();
+        List<CatalogObjectGrantMetadata> catalogObjectsGrants = new LinkedList<>(); // the user's positive grants for the catalog objects in the bucket
+        List<BucketGrantMetadata> bucketGrants = new LinkedList<>(); // the user's positive grants for the bucket
+        String bucketRights = "";
+
         if (sessionIdRequired) {
             // Check session validation
             if (!restApiAccessService.isSessionActive(sessionId)) {
                 throw new AccessDeniedException("Session id is not active. Please login.");
             }
             user = restApiAccessService.getUserFromSessionId(sessionId);
-            if (!grantAccessTypeHelperService.compareGrantAccessType(grantRightsService.getResultingAccessTypeFromUserGrantsForBucketOperations(user,
-                                                                                                                                                bucketName),
-                                                                     read.toString()) &&
-                !catalogObjectGrantService.checkInCatalogGrantsIfUserOrUserGroupHasGrantsOverABucket(user,
-                                                                                                     bucketName)) {
-                throw new BucketGrantAccessException(bucketName);
-            } else {
-                catalogObjectGrants = catalogObjectGrantService.findAllCatalogObjectGrantsAssignedToABucket(bucketName);
-            }
+            bucketGrants = grantRightsService.findAllUserBucketGrants(user, bucketName);
+            catalogObjectsGrants = catalogObjectGrantService.findAllObjectsGrantsInABucket(user, bucketName);
+            bucketRights = grantRightsService.getBucketAccessType(bucketGrants);
 
+            if (!grantAccessTypeHelperService.compareGrantAccessType(bucketRights, read.toString()) &&
+                catalogObjectsGrants.isEmpty()) {
+                throw new BucketGrantAccessException(bucketName);
+            }
         }
 
         //transform empty String into an empty Optional
@@ -392,7 +393,6 @@ public class CatalogObjectController {
         contentType = contentType.filter(s -> !s.isEmpty());
         objectNameFilter = objectNameFilter.filter(s -> !s.isEmpty());
         if (names.isPresent()) {
-
             ZipArchiveContent zipArchiveContent = catalogObjectService.getCatalogObjectsAsZipArchive(bucketName,
                                                                                                      names.get());
 
@@ -423,37 +423,49 @@ public class CatalogObjectController {
                                                                                                pageNo,
                                                                                                pageSize);
 
-            boolean doesTheUserHasAccessToTheBucketViaBucketGrant = true;
-            if (sessionIdRequired) {
-                List<BucketGrantMetadata> bucketGrantsMetadata = new LinkedList<>(grantRightsService.getAllAssignedGrantsWithHighestPriorityForUserAndHisGroups(user));
-                bucketGrantsMetadata.removeIf(grant -> !grant.getBucketName().equals(bucketName));
-                doesTheUserHasAccessToTheBucketViaBucketGrant = !bucketGrantsMetadata.isEmpty();
-            }
             /*
              * This case indicates that the user has gained access to the bucket content
              * via the object grant only, therefore all inaccessible objects will be removed
              */
-            if (!catalogObjectGrants.isEmpty() && !doesTheUserHasAccessToTheBucketViaBucketGrant) {
-                // This function remove all objects that the user has not a grant over them
-                bucketGrantService.removeAllUserInaccessibleObjectsFromTheBucket(user,
-                                                                                 metadataList,
-                                                                                 catalogObjectGrants);
-            }
-            // This function remove all objects that the user has a noAccess grant over them
             if (sessionIdRequired) {
-                grantRightsService.removeAllObjectsWithNoAccessGrant(user, metadataList, bucketName);
+                if (bucketGrants.isEmpty() && !catalogObjectsGrants.isEmpty()) {
+                    // remove all objects that the user doesn't have a positive grant over them
+                    bucketGrantService.removeObjectsWithoutGrants(metadataList, catalogObjectsGrants);
+                }
+                List<CatalogObjectGrantMetadata> objectsNoAccessGrants = catalogObjectGrantService.getUserNoAccessGrant(user);
+                List<BucketGrantMetadata> bucketNoAccessGrants = bucketGrantService.getNoAccessGrants(user, bucketName);
+                // remove all objects that the user has a noAccess grant over them
+                grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList,
+                                                                     objectsNoAccessGrants,
+                                                                     catalogObjectsGrants,
+                                                                     bucketNoAccessGrants,
+                                                                     bucketGrants);
             }
 
+            Optional<String> userSpecificBucketRights = bucketGrants.stream()
+                                                                    .filter(grant -> grant.getGranteeType()
+                                                                                          .equals("user"))
+                                                                    .findFirst()
+                                                                    .map(g -> g.getAccessType());
             for (CatalogObjectMetadata catalogObject : metadataList) {
                 if (sessionIdRequired) {
-                    catalogObject.setRights(grantRightsService.getResultingAccessTypeFromUserGrantsForCatalogObjectOperations(user,
-                                                                                                                              bucketName,
-                                                                                                                              catalogObject.getName()));
+                    List<CatalogObjectGrantMetadata> userObjectGrants = catalogObjectsGrants.stream()
+                                                                                            .filter(g -> g.getCatalogObjectName()
+                                                                                                          .equals(catalogObject.getName()))
+                                                                                            .collect(Collectors.toList());
+                    String objectRights = bucketRights;
+                    if (!userObjectGrants.isEmpty()) {
+                        objectRights = grantRightsService.getCatalogObjectAccessType(bucketName,
+                                                                                     catalogObject.getName(),
+                                                                                     userSpecificBucketRights,
+                                                                                     userObjectGrants);
+                    }
+                    catalogObject.setRights(objectRights);
                 }
+
                 catalogObject.add(LinkUtil.createLink(bucketName, catalogObject.getName()));
                 catalogObject.add(LinkUtil.createRelativeLink(bucketName, catalogObject.getName()));
             }
-
             return ResponseEntity.ok(metadataList);
         }
     }

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectGrantService.java
@@ -311,10 +311,7 @@ public class CatalogObjectGrantService {
             AuthenticatedUser user, String bucketName, String catalogObjectName) {
         return catalogObjectGrantRepository.findAllGrantsAssignedToAnObjectInsideABucket(bucketName, catalogObjectName)
                                            .stream()
-                                           .filter(grant -> (grant.getGrantee().equals(user.getName()) &&
-                                                             grant.getGranteeType().equals("user")) ||
-                                                            (user.getGroups().contains(grant.getGrantee()) &&
-                                                             grant.getGranteeType().equals("group")))
+                                           .filter(grant -> isGrantAssignedToUserOrItsGroups(user, grant))
                                            .map(CatalogObjectGrantMetadata::new)
                                            .collect(Collectors.toList());
     }
@@ -397,17 +394,20 @@ public class CatalogObjectGrantService {
      * @return a list of objects grants in the bucket assigned to the user and its groups.
      */
     public List<CatalogObjectGrantMetadata> findAllObjectsGrantsInABucket(AuthenticatedUser user, String bucketName) {
-        long bucketId = bucketRepository.findOneByBucketName(bucketName).getId();
         return findAllCatalogObjectGrantsAssignedToABucket(bucketName).stream()
-                                                                      .filter(grant -> (grant.getGrantee()
-                                                                                             .equals(user.getName()) &&
-                                                                                        grant.getGranteeType()
-                                                                                             .equals("user")) ||
-                                                                                       (user.getGroups()
-                                                                                            .contains(grant.getGrantee()) &&
-                                                                                        grant.getGranteeType()
-                                                                                             .equals("group")))
+                                                                      .filter(grant -> isGrantAssignedToUserOrItsGroups(user,
+                                                                                                                        grant))
                                                                       .collect(Collectors.toList());
+    }
+
+    private boolean isGrantAssignedToUserOrItsGroups(AuthenticatedUser user, CatalogObjectGrantMetadata grant) {
+        return (grant.getGrantee().equals(user.getName()) && grant.getGranteeType().equals("user")) ||
+               (user.getGroups().contains(grant.getGrantee()) && grant.getGranteeType().equals("group"));
+    }
+
+    private boolean isGrantAssignedToUserOrItsGroups(AuthenticatedUser user, CatalogObjectGrantEntity grant) {
+        return (grant.getGrantee().equals(user.getName()) && grant.getGranteeType().equals("user")) ||
+               (user.getGroups().contains(grant.getGrantee()) && grant.getGranteeType().equals("group"));
     }
 
     /**

--- a/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
@@ -38,7 +38,6 @@ import lombok.extern.log4j.Log4j2;
 @Transactional
 public class GrantAccessTypeHelperService {
 
-    // TODO hasAtLeastPermissionOf(String accessType, AccessType permission)
     public boolean compareGrantAccessType(String currentAccessType, String requiredAccessType) {
         // If user grant exists over this bucket, check the access type
         // else check the access type of the user group grant over this bucket

--- a/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GrantAccessTypeHelperService.java
@@ -38,6 +38,7 @@ import lombok.extern.log4j.Log4j2;
 @Transactional
 public class GrantAccessTypeHelperService {
 
+    // TODO hasAtLeastPermissionOf(String accessType, AccessType permission)
     public boolean compareGrantAccessType(String currentAccessType, String requiredAccessType) {
         // If user grant exists over this bucket, check the access type
         // else check the access type of the user group grant over this bucket

--- a/src/main/java/org/ow2/proactive/catalog/service/GrantRightsService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/GrantRightsService.java
@@ -344,18 +344,24 @@ public class GrantRightsService {
 
         List<BucketGrantMetadata> userBucketGrants = bucketGrantService.getAllBucketGrantsAssignedForTheUserOnABucket(user,
                                                                                                                       bucketName);
-        if (user.getGroups().contains(bucket.getOwner().substring(6)) ||
-            bucket.getOwner().substring(6).equals("public-objects")) {
+        addGrantsForOwnerAndPublicBucket(user, bucketName, bucket.getOwner(), userBucketGrants);
+        return userBucketGrants;
+    }
+
+    public void addGrantsForOwnerAndPublicBucket(AuthenticatedUser user, String bucketName, String bucketOwner,
+            List<BucketGrantMetadata> userBucketGrants) {
+
+        if (user.getGroups().contains(bucketOwner.substring(6)) || bucketOwner.substring(6).equals("public-objects")) {
+
             BucketGrantMetadata defaultBucketGrantMetadata = new BucketGrantMetadata("group",
                                                                                      user.getName(),
-                                                                                     bucket.getOwner().substring(6),
+                                                                                     bucketOwner.substring(6),
                                                                                      "admin",
                                                                                      5,
-                                                                                     bucket.getId(),
+                                                                                     0,
                                                                                      bucketName);
             userBucketGrants.add(defaultBucketGrantMetadata);
         }
-        return userBucketGrants;
     }
 
     /**

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketGrantServiceTest.java
@@ -294,7 +294,7 @@ public class BucketGrantServiceTest {
         when(bucketRepository.findOneByBucketName("test-write")).thenReturn(bucketWrite);
 
         when(catalogObjectGrantService.getUserNoAccessGrant(authenticatedUser)).thenReturn(new LinkedList<>());
-        when(catalogObjectGrantService.getAllGrantsAssignedToAUser(authenticatedUser)).thenReturn(new LinkedList<>());
+        when(catalogObjectGrantService.getAccessibleObjectsGrantsAssignedToAUser(authenticatedUser)).thenReturn(new LinkedList<>());
 
         List<BucketGrantEntity> bucketGrantEntityList = new LinkedList<>();
         bucketGrantEntityList.add(createBucketGrantEntity("test-noaccess", noAccess.toString()));

--- a/src/test/java/org/ow2/proactive/catalog/service/GrantRightServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/GrantRightServiceTest.java
@@ -63,7 +63,7 @@ public class GrantRightServiceTest {
         userGroups.add("user");
         AuthenticatedUser authenticatedUser = AuthenticatedUser.builder().name("user").groups(userGroups).build();
         when(catalogObjectGrantService.getUserNoAccessGrant(authenticatedUser)).thenReturn(new LinkedList<>());
-        when(catalogObjectGrantService.getAllGrantsAssignedToAUser(authenticatedUser)).thenReturn(new LinkedList<>());
+        when(catalogObjectGrantService.getAccessibleObjectsGrantsAssignedToAUser(authenticatedUser)).thenReturn(new LinkedList<>());
 
         List<BucketGrantMetadata> bucketGrantMetadataList = new LinkedList<>();
         bucketGrantMetadataList.add(createBucketGrantMetadata("user", noAccess.toString(), "bucket"));
@@ -77,11 +77,7 @@ public class GrantRightServiceTest {
         metadataList.add(createCatalogObject(bucketName, "object2"));
         metadataList.add(createCatalogObject(bucketName, "object3"));
 
-        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList,
-                                                             new LinkedList<>(),
-                                                             new LinkedList<>(),
-                                                             new LinkedList<>(),
-                                                             new LinkedList<>());
+        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList, new LinkedList<>(), new LinkedList<>());
 
         assertEquals(3, metadataList.size());
     }
@@ -92,7 +88,7 @@ public class GrantRightServiceTest {
         userGroups.add("user");
         AuthenticatedUser authenticatedUser = AuthenticatedUser.builder().name("user").groups(userGroups).build();
         when(catalogObjectGrantService.getUserNoAccessGrant(authenticatedUser)).thenReturn(new LinkedList<>());
-        when(catalogObjectGrantService.getAllGrantsAssignedToAUser(authenticatedUser)).thenReturn(new LinkedList<>());
+        when(catalogObjectGrantService.getAccessibleObjectsGrantsAssignedToAUser(authenticatedUser)).thenReturn(new LinkedList<>());
 
         List<BucketGrantMetadata> bucketGrantMetadataList = new LinkedList<>();
         bucketGrantMetadataList.add(createBucketGrantMetadata("user", noAccess.toString(), bucketName));
@@ -105,11 +101,7 @@ public class GrantRightServiceTest {
         metadataList.add(createCatalogObject(bucketName, "object2"));
         metadataList.add(createCatalogObject(bucketName, "object3"));
 
-        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList,
-                                                             new LinkedList<>(),
-                                                             new LinkedList<>(),
-                                                             bucketGrantMetadataList,
-                                                             new LinkedList<>());
+        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList, bucketGrantMetadataList, new LinkedList<>());
 
         assertEquals(0, metadataList.size());
     }
@@ -125,7 +117,7 @@ public class GrantRightServiceTest {
         List<CatalogObjectGrantMetadata> objectGrants = new LinkedList<>();
         objectGrants.add(catalogObjectGrantMetadata);
 
-        when(catalogObjectGrantService.getAllGrantsAssignedToAUser(authenticatedUser)).thenReturn(objectGrants);
+        when(catalogObjectGrantService.getAccessibleObjectsGrantsAssignedToAUser(authenticatedUser)).thenReturn(objectGrants);
 
         List<BucketGrantMetadata> bucketGrantMetadataList = new LinkedList<>();
         bucketGrantMetadataList.add(createBucketGrantMetadata("user", noAccess.toString(), bucketName));
@@ -138,11 +130,7 @@ public class GrantRightServiceTest {
         metadataList.add(createCatalogObject(bucketName, "object2"));
         metadataList.add(createCatalogObject(bucketName, "object3"));
 
-        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList,
-                                                             new LinkedList<>(),
-                                                             objectGrants,
-                                                             bucketGrantMetadataList,
-                                                             new LinkedList<>());
+        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList, bucketGrantMetadataList, objectGrants);
 
         assertEquals(1, metadataList.size());
     }

--- a/src/test/java/org/ow2/proactive/catalog/service/GrantRightServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/GrantRightServiceTest.java
@@ -77,10 +77,11 @@ public class GrantRightServiceTest {
         metadataList.add(createCatalogObject(bucketName, "object2"));
         metadataList.add(createCatalogObject(bucketName, "object3"));
 
-        grantRightsService.removeAllObjectsWithNoAccessGrant(authenticatedUser, metadataList, bucketName);
-
-        verify(catalogObjectGrantService, times(1)).getUserNoAccessGrant(authenticatedUser);
-        verify(bucketGrantService, times(1)).getAllNoAccessGrants();
+        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList,
+                                                             new LinkedList<>(),
+                                                             new LinkedList<>(),
+                                                             new LinkedList<>(),
+                                                             new LinkedList<>());
 
         assertEquals(3, metadataList.size());
     }
@@ -104,10 +105,11 @@ public class GrantRightServiceTest {
         metadataList.add(createCatalogObject(bucketName, "object2"));
         metadataList.add(createCatalogObject(bucketName, "object3"));
 
-        grantRightsService.removeAllObjectsWithNoAccessGrant(authenticatedUser, metadataList, bucketName);
-
-        verify(catalogObjectGrantService, times(1)).getUserNoAccessGrant(authenticatedUser);
-        verify(bucketGrantService, times(1)).getAllNoAccessGrants();
+        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList,
+                                                             new LinkedList<>(),
+                                                             new LinkedList<>(),
+                                                             bucketGrantMetadataList,
+                                                             new LinkedList<>());
 
         assertEquals(0, metadataList.size());
     }
@@ -136,10 +138,11 @@ public class GrantRightServiceTest {
         metadataList.add(createCatalogObject(bucketName, "object2"));
         metadataList.add(createCatalogObject(bucketName, "object3"));
 
-        grantRightsService.removeAllObjectsWithNoAccessGrant(authenticatedUser, metadataList, bucketName);
-
-        verify(catalogObjectGrantService, times(1)).getUserNoAccessGrant(authenticatedUser);
-        verify(bucketGrantService, times(1)).getAllNoAccessGrants();
+        grantRightsService.removeAllObjectsWithNoAccessGrant(metadataList,
+                                                             new LinkedList<>(),
+                                                             objectGrants,
+                                                             bucketGrantMetadataList,
+                                                             new LinkedList<>());
 
         assertEquals(1, metadataList.size());
     }


### PR DESCRIPTION
This PR aims to improve the performance of catalog requests of listing buckets and catalog objects:
- GET buckets/ 
- GET buckets/BUCKET_NAME/resources/

Performance test data on a relatively slow PC (local requests):
- GET buckets/: **before** 2000 ms - 3000 ms **after** 800 ms - 1200 ms
- GET buckets/BUCKET_NAME/resources/: **before** 5000 ms - 6000 ms **after** 400 ms - 800 ms 

Important changes:
- avoid redundant DB call: retrieve all the needed data at once (or with fewer DB queries), then filter it to get the needed data. At least, it should be avoided to send DB queries in a loop.
- reduce unnecessary loop
- use Set instead of List when a quick match needed

Small changes:
- reduce duplicate coding
- remove not used functions
- reduce double negative coding
- reduce embedded brackets levels

Potential bugs to be fixed in the future:
- The function `BucketGrantService.getTheNumberOfAccessibleObjectsInTheBucket` and `GrantRightsService.removeAllObjectsWithNoAccessGrant` need to compare grants priority. The current version may cause bugs when the user has multiple conflict group grants (or user grants) over the same catalog object / bucket.
