### PR TITLE
Fix duplicated buckets with grants and disallow downgrade user's admin rights

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketController.java
@@ -201,6 +201,7 @@ public class BucketController {
             log.debug("bucket list timer : validate session : " + (System.currentTimeMillis() - startTime) + " ms");
             listBucket = bucketService.getBucketsByGroups(ownerName, kind, contentType, objectName, user::getGroups);
             listBucket.addAll(grantRightsService.getBucketsByPrioritiedGrants(user));
+            listBucket = GrantHelper.removeDuplicate(listBucket);
 
             List<BucketGrantMetadata> allBucketsGrants = bucketGrantService.getUserAllBucketsGrants(user);
             List<CatalogObjectGrantMetadata> allCatalogObjectsGrants = catalogObjectGrantService.getObjectsGrants(user);

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
@@ -160,7 +160,7 @@ public class BucketGrantController {
                                                                                                               priority);
         if (sessionIdRequired) {
             if (user.getGroups().contains(userGroup)) {
-                if (!restApiAccessService.isBucketAccessibleByUser(true, sessionId, bucketName) &&
+                if (!restApiAccessService.isBucketAccessibleByUser(true, sessionId, bucketName) ||
                     !grantRightsService.getBucketRights(user, bucketName).equals(admin.toString())) {
                     throw new LostOfAdminGrantRightException("By updating this grant assigned to your group: " +
                                                              userGroup +

--- a/src/main/java/org/ow2/proactive/catalog/util/GrantHelper.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/GrantHelper.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.ow2.proactive.catalog.dto.BucketGrantMetadata;
+import org.ow2.proactive.catalog.dto.BucketMetadata;
 import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetadata;
 import org.ow2.proactive.catalog.dto.GrantMetadata;
 import org.ow2.proactive.catalog.repository.entity.BucketGrantEntity;
@@ -92,10 +93,6 @@ public class GrantHelper {
 
     public static <T extends GrantMetadata> List<T> filterUserSpecificGrants(List<T> grants) {
         return grants.stream().filter(GrantHelper::isUserSpecificGrant).collect(Collectors.toList());
-    }
-
-    public static List<GrantMetadata> filterGroupGrants(List<? extends GrantMetadata> grants) {
-        return grants.stream().filter(GrantHelper::isGroupGrant).collect(Collectors.toList());
     }
 
     public static <T extends GrantMetadata> List<T> filterPositiveGrants(List<T> grants) {
@@ -195,5 +192,9 @@ public class GrantHelper {
 
     public static List<CatalogObjectGrantMetadata> mapToObjectGrants(List<CatalogObjectGrantEntity> grantEntities) {
         return grantEntities.stream().map(CatalogObjectGrantMetadata::new).collect(Collectors.toList());
+    }
+
+    public static List<BucketMetadata> removeDuplicate(List<BucketMetadata> listBuckets) {
+        return listBuckets.stream().distinct().collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Fixed two bugs: 

- We should not show duplicated buckets when the user is both in the bucket owner group and has grants on the bucket. 
- When updating a group grant, even when it's just to change the grant priority, we should never allow a user to downgrade its admin right over the bucket. Otherwise, the bucket owner may lost its admin rights through first create a lower-priority not-admin grant, then increase the grant priority to be larger than 5.