### PR TITLE
Add filtering according to job-planner association status

### DIFF
--- a/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
@@ -41,6 +41,7 @@ import org.ow2.proactive.catalog.mocks.CatalogObjectGrantServiceMock;
 import org.ow2.proactive.catalog.mocks.RestApiAccessServiceMock;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
 import org.ow2.proactive.catalog.service.*;
+import org.ow2.proactive.catalog.service.helper.CommonRestTemplate;
 import org.ow2.proactive.catalog.util.ArchiveManagerHelper;
 import org.ow2.proactive.catalog.util.RawObjectResponseCreator;
 import org.ow2.proactive.catalog.util.RevisionCommitMessageBuilder;
@@ -134,6 +135,11 @@ public class IntegrationTestConfig {
     @Bean
     public GraphqlService graphqlService() {
         return new GraphqlService();
+    }
+
+    @Bean
+    public JobPlannerService jobPlannerService() {
+        return new JobPlannerService();
     }
 
     @Bean

--- a/src/integration-test/java/org/ow2/proactive/catalog/service/BucketServiceIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/service/BucketServiceIntegrationTest.java
@@ -86,7 +86,9 @@ public class BucketServiceIntegrationTest {
                                                      Optional.empty(),
                                                      Optional.empty(),
                                                      Optional.empty(),
-                                                     Optional.empty());
+                                                     Optional.empty(),
+                                                     Optional.empty(),
+                                                     (String) null);
         assertThat(emptyResult).isEmpty();
     }
 

--- a/src/integration-test/resources/application-test.properties
+++ b/src/integration-test/resources/application-test.properties
@@ -89,8 +89,18 @@ spring.jpa.hibernate.ddl-auto=create-drop
 # Disable Spring banner
 spring.main.banner_mode=off
 
+pa.scheduler.url=http://localhost:8080
+
 # Using the Scheduler as Authentication Service
-pa.scheduler.rest.url=http://localhost:8080/rest
+pa.scheduler.rest.url=${pa.scheduler.url}/rest
+
+# Used to perform filtering based on job-planner associations status
+pa.job-planner.rest.url=${pa.scheduler.url}/job-planner
+
+pa.job-planner.planned_objects.path=/planned_jobs/buckets
+pa.job-planner.planned_object.status.path=/planned_jobs/buckets/{bucketName}/{objectName}
+
+pa.job-planner.cache.timeout=60
 
 # Separator used in kind string, like workflow/pca
 kind.separator=/

--- a/src/main/java/org/ow2/proactive/catalog/dto/AssociatedObject.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/AssociatedObject.java
@@ -1,0 +1,44 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.dto;
+
+import java.io.Serializable;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+
+@Data
+public class AssociatedObject implements Serializable {
+
+    @JsonProperty("name")
+    private final String objectName;
+
+    @JsonProperty("statuses")
+    private final Set<AssociationStatus> statuses;
+}

--- a/src/main/java/org/ow2/proactive/catalog/dto/AssociatedObjectsByBucket.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/AssociatedObjectsByBucket.java
@@ -1,0 +1,52 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.dto;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+
+@Data
+public class AssociatedObjectsByBucket implements Serializable {
+
+    @JsonProperty("bucket")
+    private final String bucketName;
+
+    @JsonProperty("objects")
+    private final List<AssociatedObject> objects;
+
+    public AssociatedObject findAssociatedObject(String objectName) {
+        return objects.stream()
+                      .filter(object -> object.getObjectName().equalsIgnoreCase(objectName))
+                      .findFirst()
+                      .orElse(new AssociatedObject(objectName, new HashSet<>()));
+    }
+}

--- a/src/main/java/org/ow2/proactive/catalog/dto/AssociationStatus.java
+++ b/src/main/java/org/ow2/proactive/catalog/dto/AssociationStatus.java
@@ -1,0 +1,41 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.dto;
+
+public enum AssociationStatus {
+    PLANNED,
+    FAILED,
+    DEACTIVATED;
+
+    public static AssociationStatus convert(String status) {
+        if (status == null) {
+            return null;
+        }
+        return AssociationStatus.valueOf(status.toUpperCase());
+    }
+
+    public static final String UNPLANNED = "UNPLANNED";
+}

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepositoryImpl.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionRepositoryImpl.java
@@ -93,8 +93,10 @@ public class CatalogObjectRevisionRepositoryImpl implements CatalogObjectRevisio
 
         List<Predicate> allPredicates = getCommonPredicates(kindList, cb, root, contentType, objectName, bucketNames);
 
-        allPredicates.add(cb.equal(metadata.get("label"), WorkflowParser.OBJECT_TAG_LABEL));
-        allPredicates.add(cb.like(cb.lower(metadata.get("key")), toBothSidesPredicatePattern(tag)));
+        if (tag != null) {
+            allPredicates.add(cb.equal(metadata.get("label"), WorkflowParser.OBJECT_TAG_LABEL));
+            allPredicates.add(cb.like(cb.lower(metadata.get("key")), toBothSidesPredicatePattern(tag)));
+        }
 
         cq.where(allPredicates.toArray(new Predicate[0]));
 

--- a/src/main/java/org/ow2/proactive/catalog/service/JobPlannerService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/JobPlannerService.java
@@ -1,0 +1,140 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.Validate;
+import org.ow2.proactive.catalog.dto.AssociatedObject;
+import org.ow2.proactive.catalog.dto.AssociatedObjectsByBucket;
+import org.ow2.proactive.catalog.service.helper.CommonRestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpStatusCodeException;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import lombok.extern.log4j.Log4j2;
+
+
+@Service
+@Lazy
+@Log4j2
+public class JobPlannerService {
+
+    private final CommonRestTemplate commonRestTemplate;
+
+    @Value("${pa.job-planner.rest.url}")
+    private String jobPlannerRestUrl;
+
+    @Value("${pa.job-planner.planned_objects.path}")
+    private String plannedObjectsPaths;
+
+    @Value("${pa.job-planner.planned_object.status.path}")
+    private String plannedObjectStatusPath;
+
+    @Value("${pa.job-planner.cache.timeout}")
+    private String jobPlannerCacheTimeout;
+
+    private Cache<String, List<AssociatedObjectsByBucket>> jobPlannerAllAssociationsCache;
+
+    private Cache<String, AssociatedObject> jobPlannerAssociationCache;
+
+    @Autowired
+    public JobPlannerService() {
+        this.commonRestTemplate = new CommonRestTemplate();
+        int timeout = jobPlannerCacheTimeout != null ? Integer.parseInt(jobPlannerCacheTimeout) : 0;
+        jobPlannerAllAssociationsCache = CacheBuilder.newBuilder().expireAfterWrite(timeout, TimeUnit.SECONDS).build();
+        jobPlannerAssociationCache = CacheBuilder.newBuilder().expireAfterWrite(timeout, TimeUnit.SECONDS).build();
+    }
+
+    public synchronized List<AssociatedObjectsByBucket> getAssociatedObjects(String sessionId) {
+        Validate.notNull(sessionId, "SessionId must not be null");
+        List<AssociatedObjectsByBucket> answer = jobPlannerAllAssociationsCache.getIfPresent(sessionId);
+        if (answer == null) {
+            ResponseEntity<AssociatedObjectsByBucket[]> listResponseEntity;
+            String url = jobPlannerRestUrl + plannedObjectsPaths;
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("sessionid", sessionId);
+            headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+            HttpEntity<String> entity = new HttpEntity<String>(headers);
+            try {
+                listResponseEntity = commonRestTemplate.getRestTemplate().exchange(url,
+                                                                                   HttpMethod.GET,
+                                                                                   entity,
+                                                                                   AssociatedObjectsByBucket[].class);
+                answer = Arrays.asList(listResponseEntity.getBody());
+            } catch (HttpStatusCodeException httpException) {
+                log.error(String.format("Could not retrieve job-planner associated objects, http response is: %s",
+                                        httpException.getResponseBodyAsString()));
+                answer = Collections.emptyList();
+            }
+            jobPlannerAllAssociationsCache.put(sessionId, answer);
+        }
+        return answer;
+    }
+
+    public synchronized AssociatedObject getAssociatedObject(String sessionId, String bucketName, String objectName) {
+        Validate.notNull(sessionId, "SessionId must not be null");
+        Validate.notNull(bucketName, "bucketName must not be null");
+        Validate.notNull(objectName, "objectName must not be null");
+        String key = sessionId + "_" + bucketName + "_" + objectName;
+        AssociatedObject answer = jobPlannerAssociationCache.getIfPresent(key);
+        if (answer == null) {
+            ResponseEntity<AssociatedObject> responseEntity;
+            String url = jobPlannerRestUrl + plannedObjectStatusPath;
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("sessionid", sessionId);
+            headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+            HttpEntity<String> entity = new HttpEntity<String>(headers);
+            try {
+                responseEntity = commonRestTemplate.getRestTemplate()
+                                                   .exchange(url,
+                                                             HttpMethod.GET,
+                                                             entity,
+                                                             AssociatedObject.class,
+                                                             bucketName,
+                                                             objectName);
+                answer = responseEntity.getBody();
+            } catch (HttpStatusCodeException httpException) {
+                log.error(String.format("Could not retrieve job-planner associated object, http response is: %s",
+                                        httpException.getResponseBodyAsString()));
+                answer = new AssociatedObject(objectName, new HashSet<>());
+            }
+            jobPlannerAssociationCache.put(key, answer);
+        }
+        return answer;
+    }
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/helper/CommonRestTemplate.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/helper/CommonRestTemplate.java
@@ -1,0 +1,65 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service.helper;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.ow2.proactive.microservices.common.exception.ServerException;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.Getter;
+
+
+public class CommonRestTemplate {
+
+    @Getter
+    private RestTemplate restTemplate;
+
+    public CommonRestTemplate() {
+        try (CloseableHttpClient httpClient = HttpClients.custom()
+                                                         .setSSLContext(new SSLContextBuilder().loadTrustMaterial(null,
+                                                                                                                  (certificate,
+                                                                                                                          authType) -> true)
+                                                                                               .build())
+                                                         .setSSLHostnameVerifier(new NoopHostnameVerifier())
+                                                         .setConnectionManagerShared(true)
+                                                         .build()) {
+            HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+            restTemplate = new RestTemplate(requestFactory);
+        } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException | IOException e) {
+            new ServerException("Unable to set rest template for https request", e);
+        }
+    }
+
+}

--- a/src/main/java/org/ow2/proactive/catalog/service/model/JobPlannerObjectAssociations.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/model/JobPlannerObjectAssociations.java
@@ -1,0 +1,39 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.catalog.service.model;
+
+import java.util.Set;
+
+import lombok.Data;
+
+
+@Data
+public class JobPlannerObjectAssociations {
+
+    private String objectName;
+
+    private Set<String> statuses;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -101,6 +101,15 @@ pa.scheduler.url=http://localhost:8080
 # Used to perform authentication since identity service is not yet available
 pa.scheduler.rest.url=${pa.scheduler.url}/rest
 
+# Used to perform filtering based on job-planner associations status
+pa.job-planner.rest.url=${pa.scheduler.url}/job-planner
+
+pa.job-planner.planned_objects.path=/planned_jobs/buckets
+pa.job-planner.planned_object.status.path=/planned_jobs/buckets/{bucketName}/{objectName}
+
+# duration of job-planner association cache in seconds
+pa.job-planner.cache.timeout=60
+
 # Separator used in kind string, like workflow/pca
 kind.separator=/
 

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/BucketControllerTest.java
@@ -89,8 +89,15 @@ public class BucketControllerTest {
                               type,
                               Optional.ofNullable(null),
                               Optional.ofNullable(null),
+                              Optional.ofNullable(null),
                               Optional.ofNullable(null));
-        verify(bucketService, times(1)).listBuckets((String) null, kind, type, Optional.empty(), Optional.empty());
+        verify(bucketService, times(1)).listBuckets((String) null,
+                                                    kind,
+                                                    type,
+                                                    Optional.empty(),
+                                                    Optional.empty(),
+                                                    Optional.empty(),
+                                                    null);
     }
 
     @Test
@@ -100,12 +107,15 @@ public class BucketControllerTest {
         Optional name = Optional.ofNullable("");
         Optional bucket = Optional.ofNullable("");
         Optional tag = Optional.ofNullable("");
-        bucketController.list(null, null, kind, type, name, bucket, tag);
+        Optional associationStatus = Optional.ofNullable("");
+        bucketController.list(null, null, kind, type, name, bucket, tag, associationStatus);
         verify(bucketService, times(1)).listBuckets((String) null,
                                                     Optional.empty(),
                                                     Optional.empty(),
                                                     Optional.empty(),
-                                                    Optional.empty());
+                                                    Optional.empty(),
+                                                    Optional.empty(),
+                                                    null);
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerTest.java
@@ -126,6 +126,7 @@ public class CatalogObjectControllerTest {
                                      Optional.empty(),
                                      Optional.empty(),
                                      Optional.empty(),
+                                     Optional.empty(),
                                      Optional.of(nameList),
                                      0,
                                      Integer.MAX_VALUE,
@@ -157,6 +158,7 @@ public class CatalogObjectControllerTest {
                                      Optional.empty(),
                                      Optional.empty(),
                                      Optional.empty(),
+                                     Optional.empty(),
                                      Optional.of(nameList),
                                      0,
                                      Integer.MAX_VALUE,
@@ -174,6 +176,7 @@ public class CatalogObjectControllerTest {
         when(bucketRepository.findOneByBucketName("bucket-name")).thenReturn(bucket);
         catalogObjectController.list("",
                                      "bucket-name",
+                                     Optional.empty(),
                                      Optional.empty(),
                                      Optional.empty(),
                                      Optional.empty(),

--- a/src/test/java/org/ow2/proactive/catalog/service/BucketServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/BucketServiceTest.java
@@ -88,7 +88,7 @@ public class BucketServiceTest {
 
     @Test
     public void testThatEmptyListIsReturnedIfListAndKindAreNull() {
-        assertThat(bucketService.listBuckets((List<String>) null, null, null, null, null)).isEmpty();
+        assertThat(bucketService.listBuckets((List<String>) null, null, null, null, null, null, null)).isEmpty();
         verify(bucketRepository, times(0)).findBucketByOwnerContainingKindListAndContentTypeAndObjectName(any(),
                                                                                                           any(),
                                                                                                           any(),
@@ -104,7 +104,9 @@ public class BucketServiceTest {
                                              kind,
                                              Optional.empty(),
                                              Optional.empty(),
-                                             Optional.empty())).isEmpty();
+                                             Optional.empty(),
+                                             Optional.empty(),
+                                             (String) null)).isEmpty();
         verify(bucketRepository, times(0)).findBucketByOwnerContainingKindListAndContentTypeAndObjectName(any(),
                                                                                                           any(),
                                                                                                           any(),


### PR DESCRIPTION
 - added a JobPlannerService (with configuration and cache of 1 minute)
 - add new associationStatus filter in BucketController and CatalogObjectController
 - association status information is returned as a metadata of the catalog objetcs