### PR TITLE
Improve performance of job-planner filtering

### DIFF
--- a/src/integration-test/resources/application-test.properties
+++ b/src/integration-test/resources/application-test.properties
@@ -107,3 +107,5 @@ kind.separator=/
 
 # Optional catalog security features
 pa.catalog.security.required.sessionid=false
+
+pa.catalog.db.items.max.size=1000

--- a/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionCustom.java
+++ b/src/main/java/org/ow2/proactive/catalog/repository/CatalogObjectRevisionCustom.java
@@ -40,7 +40,7 @@ public interface CatalogObjectRevisionCustom {
             int pageSize);
 
     List<CatalogObjectRevisionEntity> findDefaultCatalogObjectsOfKindListAndContentTypeAndObjectNameAndTagInBucket(
-            List<String> bucketNames, List<String> kindList, String contentType, String objectName, String tag,
-            int pageNo, int pageSize);
+            List<String> bucketNames, List<String> objectNames, List<String> kindList, String contentType,
+            String objectName, String tag, int pageNo, int pageSize);
 
 }

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -604,6 +604,7 @@ public class CatalogObjectService {
                                                                                                                                 pageSize);
         } else {
             objectList = catalogObjectRevisionRepository.findDefaultCatalogObjectsOfKindListAndContentTypeAndObjectNameAndTagInBucket(bucketNames,
+                                                                                                                                      null,
                                                                                                                                       kindList,
                                                                                                                                       contentType,
                                                                                                                                       objectName,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -125,3 +125,6 @@ pa.catalog.pdf.report.ttf.font.bold.italic.path=
 # Session id cache timeout value in minutes
 pa.catalog.sessionId.timeout.minutes = 1
 
+# the maximum number of items that can be used in a SQL IN expression (default to Oracle limit)
+pa.catalog.db.items.max.size=1000
+


### PR DESCRIPTION
When the association status filter is anything but UNPLANNED, we can query the job-planner service for all associated objects and retrieve from the db catalog object entities according to this list.

In case of UNPLANNED, it is not possible to do this filtering and the performance will not be improved.

Also, add pa.catalog.db.items.max.size to control the SQL in expression size