### PR TITLE
Replace springfox swagger with springdoc OpenAPI 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,9 +224,7 @@ dependencies {
 
     providedRuntime 'org.hsqldb:hsqldb:2.7.2:jdk8'
 
-    compile 'io.springfox:springfox-spring-web'
-    compile 'io.springfox:springfox-swagger2'
-    compile 'io.springfox:springfox-swagger-ui'
+    compile 'org.springdoc:springdoc-openapi-ui:1.7.0'
 
     compile 'com.graphql-java:graphql-java:14.1'
     compile 'org.projectlombok:lombok'

--- a/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/IntegrationTestConfig.java
@@ -41,7 +41,6 @@ import org.ow2.proactive.catalog.mocks.CatalogObjectGrantServiceMock;
 import org.ow2.proactive.catalog.mocks.RestApiAccessServiceMock;
 import org.ow2.proactive.catalog.repository.entity.CatalogObjectRevisionEntity;
 import org.ow2.proactive.catalog.service.*;
-import org.ow2.proactive.catalog.service.helper.CommonRestTemplate;
 import org.ow2.proactive.catalog.util.ArchiveManagerHelper;
 import org.ow2.proactive.catalog.util.RawObjectResponseCreator;
 import org.ow2.proactive.catalog.util.RevisionCommitMessageBuilder;

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectControllerIntegrationTest.java
@@ -410,11 +410,12 @@ public class CatalogObjectControllerIntegrationTest extends AbstractRestAssuredT
                                                       .then()
                                                       .assertThat()
                                                       .statusCode(HttpStatus.SC_OK);
-        metadataResponse.body("_links.content.href",
+        metadataResponse.body("links[0].rel", is("content"))
+                        .body("links[0].href",
                               containsString("/buckets/" + bucket.getName() + "/resources/" + encodedObjectName +
                                              "/raw"))
-                        .body("_links.relative.href",
-                              is("buckets/" + bucket.getName() + "/resources/" + encodedObjectName));
+                        .body("links[1].rel", is("relative"))
+                        .body("links[1].href", is("buckets/" + bucket.getName() + "/resources/" + encodedObjectName));
     }
 
     @Test

--- a/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionControllerIntegrationTest.java
@@ -294,11 +294,13 @@ public class CatalogObjectRevisionControllerIntegrationTest extends AbstractCata
                            .body("object_key_values.find { it.key=='var2' }.label", is("variable"))
                            .body("object_key_values.find { it.key=='var2' }.value", is("var2ValueUpdated"))
                            //check link references
-                           .body("_links.content.href",
+                           .body("links[0].rel", is("content"))
+                           .body("links[0].href",
                                  containsString("/buckets/" + bucket.getName() + "/resources/" + encodedObjectName +
                                                 "/revisions/" + secondCatalogObjectRevision.get("commit_time_raw") +
                                                 "/raw"))
-                           .body("_links.relative.href",
+                           .body("links[1].rel", is("relative"))
+                           .body("links[1].href",
                                  is("buckets/" + bucket.getName() + "/resources/" + encodedObjectName + "/revisions/" +
                                     secondCatalogObjectRevision.get("commit_time_raw")));
     }

--- a/src/main/java/org/ow2/proactive/catalog/Application.java
+++ b/src/main/java/org/ow2/proactive/catalog/Application.java
@@ -25,14 +25,11 @@
  */
 package org.ow2.proactive.catalog;
 
-import static springfox.documentation.schema.AlternateTypeRules.newRule;
-
 import java.io.File;
 
 import javax.sql.DataSource;
 
 import org.ow2.proactive.catalog.util.EntityScanRoot;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -43,32 +40,18 @@ import org.springframework.boot.autoconfigure.web.MultipartAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.core.io.InputStreamResource;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.http.MediaType;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartResolver;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
-import com.fasterxml.classmate.TypeResolver;
-import com.google.common.base.Predicate;
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 
 
 /**
@@ -76,7 +59,6 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
  */
 @SpringBootApplication(scanBasePackages = { "org.ow2.proactive.catalog" })
 @EnableAutoConfiguration(exclude = { MultipartAutoConfiguration.class })
-@EnableSwagger2
 @EnableTransactionManagement
 @EnableEncryptableProperties
 @EntityScan(basePackages = "org.ow2.proactive.catalog.repository.entity")
@@ -144,36 +126,16 @@ public class Application extends WebMvcConfigurerAdapter {
         return new CommonsMultipartResolver();
     }
 
-    @Autowired
-    private TypeResolver typeResolver;
-
     @Bean
-    public Docket workflowCatalogApi() {
-        return new Docket(DocumentationType.SWAGGER_2).apiInfo(apiInfo())
-                                                      .groupName("CatalogObjectEntity Catalog")
-                                                      .ignoredParameterTypes(Pageable.class,
-                                                                             PagedResourcesAssembler.class)
-                                                      .alternateTypeRules(newRule(typeResolver.resolve(InputStreamResource.class),
-                                                                                  typeResolver.resolve(MultipartFile.class)))
-                                                      .select()
-                                                      .paths(allowedPaths())
-                                                      .build()
-                                                      .forCodeGeneration(true);
-    }
-
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder().title("CatalogObjectEntity Catalog API")
-                                   .description("The purpose of the catalog is to store ProActive objects.\n" + "\n" +
-                                                "A catalog is subdivided into buckets.\n\n Each bucket manages zero, one or more\n" +
-                                                "versioned ProActive objects.")
-                                   .license("GNU Affero General Public License v3.0")
-                                   .licenseUrl("https://github.com/ow2-proactive/catalog/blob/master/LICENSE.txt")
-                                   .version("1.0")
-                                   .build();
-    }
-
-    private Predicate<String> allowedPaths() {
-        return PathSelectors.regex("/buckets.*");
+    public OpenAPI workflowCatalogOpenAPI() {
+        return new OpenAPI().info(new Info().title("CatalogObjectEntity Catalog API")
+                                            .description("The purpose of the catalog is to store ProActive objects.\n" +
+                                                         "\n" +
+                                                         "A catalog is subdivided into buckets.\n\n Each bucket manages zero, one or more\n" +
+                                                         "versioned ProActive objects.")
+                                            .version("1.0\"")
+                                            .license(new License().name("GNU Affero General Public License v3.0")
+                                                                  .url("https://github.com/ow2-proactive/catalog/blob/master/LICENSE.txt")));
     }
 
 }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/BucketGrantController.java
@@ -28,7 +28,7 @@ package org.ow2.proactive.catalog.rest.controller;
 import static org.ow2.proactive.catalog.util.AccessType.admin;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
 
-import java.util.*;
+import java.util.List;
 
 import org.ow2.proactive.catalog.dto.BucketGrantMetadata;
 import org.ow2.proactive.catalog.service.BucketGrantService;
@@ -40,6 +40,7 @@ import org.ow2.proactive.catalog.service.exception.LostOfAdminGrantRightExceptio
 import org.ow2.proactive.catalog.service.exception.PublicBucketGrantAccessException;
 import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
 import org.ow2.proactive.catalog.util.AllBucketGrants;
+import org.ow2.proactive.catalog.util.name.validator.BucketNameValidator;
 import org.ow2.proactive.microservices.common.exception.NotAuthenticatedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,10 +48,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.log4j.Log4j2;
 
 
@@ -83,17 +85,18 @@ public class BucketGrantController {
     private boolean sessionIdRequired;
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Update the access type of an existing user bucket grant")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Update the access type of an existing user bucket grant")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant/user", method = PUT)
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     public BucketGrantMetadata updateBucketGrantForAUser(
-            @ApiParam(value = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable String bucketName,
-            @ApiParam(value = "The name of the user that is benefiting from the access grant.", required = true, defaultValue = "") @RequestParam(value = "username", required = true, defaultValue = "") String username,
-            @ApiParam(value = "The new type of the access grant. It can be either noAccess, read, write or admin.", required = true, defaultValue = "") @RequestParam(value = "accessType", required = true, defaultValue = "") String accessType)
+            @Parameter(description = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable String bucketName,
+            @Parameter(description = "The name of the user that is benefiting from the access grant.", required = true) @RequestParam(value = "username", required = true, defaultValue = "") String username,
+            @Parameter(description = "The new type of the access grant. It can be either noAccess, read, write or admin.", schema = @Schema(type = "string", allowableValues = { "noAccess",
+                                                                                                                                                                                 "read", "write", "admin" }), required = true) @RequestParam(value = "accessType", required = true, defaultValue = "") String accessType)
             throws NotAuthenticatedException, AccessDeniedException {
         AuthenticatedUser user;
         String initiator = ANONYMOUS;
@@ -122,19 +125,21 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Update the access type of an existing group bucket grant")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Update the access type of an existing group bucket grant")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant/group", method = PUT)
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     public BucketGrantMetadata updateBucketGrantForAGroup(
-            @ApiParam(value = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable String bucketName,
-            @ApiParam(value = "The name of the group of users that are benefiting from the access grant.", required = true, defaultValue = "") @RequestParam(value = "userGroup", required = true, defaultValue = "") String userGroup,
-            @ApiParam(value = "The new type of the access grant. It can be either noAccess, read, write or admin.", required = true, defaultValue = "") @RequestParam(value = "accessType", required = true, defaultValue = "") String accessType,
-            @ApiParam(value = "The new priority of the access grant. It can be a value from 1 (lowest) to 10 (highest), with 5 as default.\n" +
-                              "Priorities are used to compute the final access rights of a user belonging to multiple groups. Group grants with the same priority will resolve with the default accessType order (admin > write > read > noAccess).\n" + "Finally, please note that a user grant has always more priority than a group grant.", required = true) @RequestParam(value = "priority", required = true) int priority)
+            @Parameter(description = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable String bucketName,
+            @Parameter(description = "The name of the group of users that are benefiting from the access grant.", required = true) @RequestParam(value = "userGroup", required = true, defaultValue = "") String userGroup,
+            @Parameter(description = "The new type of the access grant. It can be either noAccess, read, write or admin.", schema = @Schema(type = "string", allowableValues = { "noAccess",
+                                                                                                                                                                                 "read", "write", "admin" }), required = true) @RequestParam(value = "accessType", required = true, defaultValue = "") String accessType,
+            @Parameter(description = "The new priority of the access grant.<br />It can be a value from 1 (lowest) to 10 (highest), with 5 as default." +
+                                     "Priorities are used to compute the final access rights of a user belonging to multiple groups.<br />Group grants with the same priority will resolve with the default accessType order (admin > write > read > noAccess).<br />" +
+                                     "Finally, please note that a user grant has always more priority than a group grant.", schema = @Schema(type = "integer", minimum = "1", maximum = "10", defaultValue = "5"), required = true) @RequestParam(value = "priority", required = true) int priority)
             throws NotAuthenticatedException, AccessDeniedException {
         AuthenticatedUser user;
         String initiator = ANONYMOUS;
@@ -168,16 +173,16 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Delete a user grant access for a bucket")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Delete a user grant access for a bucket")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant/user", method = DELETE)
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     public BucketGrantMetadata deleteBucketGrantForAUser(
-            @ApiParam(value = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable(value = "bucketName") String bucketName,
-            @ApiParam(value = "The name of the user that is benefiting from the access grant.", required = true, defaultValue = "") @RequestParam(value = "username", required = true, defaultValue = "") String username)
+            @Parameter(description = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable(value = "bucketName") String bucketName,
+            @Parameter(description = "The name of the user that is benefiting from the access grant.", required = true) @RequestParam(value = "username", required = true, defaultValue = "") String username)
             throws NotAuthenticatedException, AccessDeniedException {
         AuthenticatedUser user;
         String initiator = ANONYMOUS;
@@ -203,16 +208,16 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Delete a group grant access for a bucket")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Delete a group grant access for a bucket")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant/group", method = DELETE)
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     public BucketGrantMetadata deleteBucketGrantForAGroup(
-            @ApiParam(value = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable(value = "bucketName") String bucketName,
-            @ApiParam(value = "The name of the group of users that are benefiting from the access grant.", required = true, defaultValue = "") @RequestParam(value = "userGroup", required = true, defaultValue = "") String userGroup)
+            @Parameter(description = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable(value = "bucketName") String bucketName,
+            @Parameter(description = "The name of the group of users that are benefiting from the access grant.", required = true) @RequestParam(value = "userGroup", required = true, defaultValue = "") String userGroup)
             throws NotAuthenticatedException, AccessDeniedException {
         AuthenticatedUser user;
         String initiator = ANONYMOUS;
@@ -241,14 +246,14 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Get all grants associated with a bucket")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Get all grants associated with a bucket")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant", method = GET)
     @ResponseStatus(HttpStatus.OK)
     public List<BucketGrantMetadata> getAllGrantsForABucket(
-            @ApiParam(value = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable(value = "bucketName") String bucketName) {
+            @Parameter(description = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable(value = "bucketName") String bucketName) {
         if (sessionIdRequired) {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             // Check session validation
@@ -258,17 +263,18 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Create a new user grant access for a bucket")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Create a new user grant access for a bucket")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant/user", method = POST)
     @ResponseStatus(HttpStatus.CREATED)
     @Transactional
     public BucketGrantMetadata createBucketGrantForAUser(
-            @ApiParam(value = "The the session id used to access ProActive REST server", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable(value = "bucketName") String bucketName,
-            @ApiParam(value = "The type of the access grant. It can be either noAccess, read, write or admin.", required = true) @RequestParam(value = "accessType", required = true) String accessType,
-            @ApiParam(value = "The name of the user that will benefit of the access grant.", required = true, defaultValue = "") @RequestParam(value = "username", required = true, defaultValue = "") String username)
+            @Parameter(description = "The the session id used to access ProActive REST server", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable(value = "bucketName") String bucketName,
+            @Parameter(description = "The type of the access grant.<br />It can be either noAccess, read, write or admin.", schema = @Schema(type = "string", allowableValues = { "noAccess",
+                                                                                                                                                                                  "read", "write", "admin" }), required = true) @RequestParam(value = "accessType", required = true) String accessType,
+            @Parameter(description = "The name of the user that will benefit of the access grant.", required = true) @RequestParam(value = "username", required = true, defaultValue = "") String username)
             throws NotAuthenticatedException, AccessDeniedException {
         AuthenticatedUser user;
         String initiator = ANONYMOUS;
@@ -298,20 +304,21 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Create a new user group grant access for a bucket")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Create a new user group grant access for a bucket")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant/group", method = POST)
     @ResponseStatus(HttpStatus.CREATED)
     @Transactional
     public BucketGrantMetadata createBucketGrantForAGroup(
-            @ApiParam(value = "The session id used to access ProActive REST server", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable(value = "bucketName") String bucketName,
-            @ApiParam(value = "The type of the access grant. It can be either noAccess, read, write or admin.", required = true) @RequestParam(value = "accessType", required = true) String accessType,
-            @ApiParam(value = "The new priority of the access grant. It can be a value from 1 (lowest) to 10 (highest), with 5 as default.\n" +
-                              "Priorities are used to compute the final access rights of a user belonging to multiple groups. Group grants with the same priority will resolve with the default accessType order (admin > write > read > noAccess).\n" +
-                              "Finally, please note that a user grant has always more priority than a group grant.", required = true, defaultValue = "5") @RequestParam(value = "priority", required = true, defaultValue = "5") int priority,
-            @ApiParam(value = "The name of the group of users that will benefit of the access grant.", required = true, defaultValue = "") @RequestParam(value = "userGroup", required = true, defaultValue = "") String userGroup)
+            @Parameter(description = "The session id used to access ProActive REST server", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable(value = "bucketName") String bucketName,
+            @Parameter(description = "The type of the access grant.<br />It can be either noAccess, read, write or admin.", schema = @Schema(type = "string", allowableValues = { "noAccess",
+                                                                                                                                                                                  "read", "write", "admin" }), required = true) @RequestParam(value = "accessType", required = true) String accessType,
+            @Parameter(description = "The new priority of the access grant.<br />It can be a value from 1 (lowest) to 10 (highest), with 5 as default.\n" +
+                                     "Priorities are used to compute the final access rights of a user belonging to multiple groups.<br />Group grants with the same priority will resolve with the default accessType order (admin > write > read > noAccess).<br />" +
+                                     "Finally, please note that a user grant has always more priority than a group grant.", schema = @Schema(type = "integer", minimum = "1", maximum = "10", defaultValue = "5"), required = true) @RequestParam(value = "priority", required = true, defaultValue = "5") int priority,
+            @Parameter(description = "The name of the group of users that will benefit of the access grant.", required = true) @RequestParam(value = "userGroup", required = true, defaultValue = "") String userGroup)
             throws NotAuthenticatedException, AccessDeniedException {
         AuthenticatedUser user;
         String initiator = ANONYMOUS;
@@ -343,14 +350,14 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Delete all grants assigned to a bucket")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Delete all grants assigned to a bucket")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant", method = DELETE)
     @ResponseStatus(HttpStatus.OK)
     public List<BucketGrantMetadata> deleteAllBucketGrantsAssignedToABucket(
-            @ApiParam(value = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable(value = "bucketName") String bucketName)
+            @Parameter(description = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable(value = "bucketName") String bucketName)
             throws NotAuthenticatedException, AccessDeniedException {
         String initiator = ANONYMOUS;
         if (sessionIdRequired) {
@@ -365,14 +372,14 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Get all grants associated with a bucket and all objects contained in this bucket")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Get all grants associated with a bucket and all objects contained in this bucket")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant/all", method = GET)
     @ResponseStatus(HttpStatus.OK)
     public AllBucketGrants getAllGrantsForABucketAndItsObjects(
-            @ApiParam(value = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable(value = "bucketName") String bucketName) {
+            @Parameter(description = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable(value = "bucketName") String bucketName) {
         if (sessionIdRequired) {
             AuthenticatedUser user = restApiAccessService.getUserFromSessionId(sessionId);
             // Check session validation
@@ -382,15 +389,15 @@ public class BucketGrantController {
     }
 
     @SuppressWarnings("DefaultAnnotationParam")
-    @ApiOperation(value = "Delete all grants associated with a bucket and all objects contained in this bucket")
-    @ApiResponses(value = { @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"), })
+    @Operation(summary = "Delete all grants associated with a bucket and all objects contained in this bucket")
+    @ApiResponses(value = { @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"), })
     @RequestMapping(value = "/{bucketName}/grant/all", method = DELETE)
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     public AllBucketGrants deleteAllGrantsForABucketAndItsObjects(
-            @ApiParam(value = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @ApiParam(value = "The name of the bucket where the catalog objects are stored.", required = true) @PathVariable(value = "bucketName") String bucketName) {
+            @Parameter(description = "The session id used to access ProActive REST server.", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the bucket where the catalog objects are stored.", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable(value = "bucketName") String bucketName) {
         AuthenticatedUser user;
         String initiator = ANONYMOUS;
         if (sessionIdRequired) {

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectRevisionController.java
@@ -25,10 +25,9 @@
  */
 package org.ow2.proactive.catalog.rest.controller;
 
-import static org.ow2.proactive.catalog.util.AccessType.*;
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-import static org.springframework.web.bind.annotation.RequestMethod.POST;
-import static org.springframework.web.bind.annotation.RequestMethod.PUT;
+import static org.ow2.proactive.catalog.util.AccessType.read;
+import static org.ow2.proactive.catalog.util.AccessType.write;
+import static org.springframework.web.bind.annotation.RequestMethod.*;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -39,36 +38,29 @@ import java.util.Optional;
 import org.ow2.proactive.catalog.dto.CatalogObjectGrantMetadata;
 import org.ow2.proactive.catalog.dto.CatalogObjectMetadata;
 import org.ow2.proactive.catalog.dto.CatalogRawObject;
-import org.ow2.proactive.catalog.service.BucketGrantService;
-import org.ow2.proactive.catalog.service.CatalogObjectGrantService;
-import org.ow2.proactive.catalog.service.CatalogObjectService;
-import org.ow2.proactive.catalog.service.GrantRightsService;
-import org.ow2.proactive.catalog.service.RestApiAccessService;
+import org.ow2.proactive.catalog.service.*;
 import org.ow2.proactive.catalog.service.exception.AccessDeniedException;
 import org.ow2.proactive.catalog.service.exception.BucketGrantAccessException;
 import org.ow2.proactive.catalog.service.model.AuthenticatedUser;
 import org.ow2.proactive.catalog.util.AccessTypeHelper;
 import org.ow2.proactive.catalog.util.LinkUtil;
 import org.ow2.proactive.catalog.util.RawObjectResponseCreator;
+import org.ow2.proactive.catalog.util.name.validator.BucketNameValidator;
+import org.ow2.proactive.catalog.util.name.validator.ObjectNameValidator;
 import org.ow2.proactive.microservices.common.exception.NotAuthenticatedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.log4j.Log4j2;
 
 
@@ -105,19 +97,20 @@ public class CatalogObjectRevisionController {
     @Value("${pa.catalog.security.required.sessionid}")
     private boolean sessionIdRequired;
 
-    @ApiOperation(value = "Creates a new catalog object revision")
-    @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket not found"),
-                            @ApiResponse(code = 422, message = "Invalid catalog object JSON content supplied"),
-                            @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied") })
+    @Operation(summary = "Creates a new catalog object revision")
+    @ApiResponses(value = { @ApiResponse(responseCode = "404", description = "Bucket not found"),
+                            @ApiResponse(responseCode = "422", description = "Invalid catalog object JSON content supplied"),
+                            @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied") })
     @RequestMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE }, method = POST)
     @ResponseStatus(HttpStatus.CREATED)
     public CatalogObjectMetadata create(
-            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @PathVariable String bucketName, @PathVariable String name,
-            @ApiParam(value = "The commit message of the CatalogRawObject Revision", required = true) @RequestParam String commitMessage,
-            @ApiParam(value = "Project of the object") @RequestParam(value = "projectName", required = false, defaultValue = "") Optional<String> projectName,
-            @ApiParam(value = "Tags of the object") @RequestParam(value = "tags", required = false, defaultValue = "") Optional<String> tags,
+            @Parameter(description = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the existing Bucket", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable String bucketName,
+            @Parameter(description = "The name of the existing Object", required = true, schema = @Schema(pattern = ObjectNameValidator.VALID_OBJECT_NAME_PATTERN)) @PathVariable String name,
+            @Parameter(description = "The commit message of the CatalogRawObject Revision", required = true) @RequestParam String commitMessage,
+            @Parameter(description = "Project of the object") @RequestParam(value = "projectName", required = false, defaultValue = "") Optional<String> projectName,
+            @Parameter(description = "Tags of the object") @RequestParam(value = "tags", required = false, defaultValue = "") Optional<String> tags,
             @RequestPart(value = "file") MultipartFile file)
             throws IOException, NotAuthenticatedException, AccessDeniedException {
         AuthenticatedUser user;
@@ -158,15 +151,17 @@ public class CatalogObjectRevisionController {
         return catalogObjectRevision;
     }
 
-    @ApiOperation(value = "Gets a specific revision")
-    @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket, catalog object or catalog object revision not found"),
-                            @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied") })
+    @Operation(summary = "Gets a specific revision")
+    @ApiResponses(value = { @ApiResponse(responseCode = "404", description = "Bucket, catalog object or catalog object revision not found"),
+                            @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied") })
     @RequestMapping(value = "/{commitTimeRaw}", method = GET)
     @ResponseStatus(HttpStatus.OK)
     public CatalogObjectMetadata get(
-            @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
-            @PathVariable String bucketName, @PathVariable String name, @PathVariable long commitTimeRaw)
+            @Parameter(description = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
+            @Parameter(description = "The name of the existing Bucket", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable String bucketName,
+            @Parameter(description = "The name of the existing Object", required = true, schema = @Schema(pattern = ObjectNameValidator.VALID_OBJECT_NAME_PATTERN)) @PathVariable String name,
+            @PathVariable long commitTimeRaw)
             throws UnsupportedEncodingException, NotAuthenticatedException, AccessDeniedException {
         if (sessionIdRequired) {
             // Check session validation
@@ -188,16 +183,18 @@ public class CatalogObjectRevisionController {
 
     }
 
-    @ApiOperation(value = "Gets the raw content of a specific revision")
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "Ok"),
-                            @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied"),
-                            @ApiResponse(code = 404, message = "Bucket, catalog object or catalog object revision not found") })
+    @Operation(summary = "Gets the raw content of a specific revision")
+    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Ok"),
+                            @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied"),
+                            @ApiResponse(responseCode = "404", description = "Bucket, catalog object or catalog object revision not found") })
     @RequestMapping(value = "/{commitTimeRaw}/raw", method = GET, produces = MediaType.ALL_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<String> getRaw(
-            @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
-            @PathVariable String bucketName, @PathVariable String name, @PathVariable long commitTimeRaw)
+            @Parameter(description = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
+            @Parameter(description = "The name of the existing Bucket", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable String bucketName,
+            @Parameter(description = "The name of the existing Object", required = true, schema = @Schema(pattern = ObjectNameValidator.VALID_OBJECT_NAME_PATTERN)) @PathVariable String name,
+            @PathVariable long commitTimeRaw)
             throws UnsupportedEncodingException, NotAuthenticatedException, AccessDeniedException {
         if (sessionIdRequired) {
             // Check session validation
@@ -219,15 +216,16 @@ public class CatalogObjectRevisionController {
         return rawObjectResponseCreator.createRawObjectResponse(objectRevisionRaw);
     }
 
-    @ApiOperation(value = "Lists a catalog object revisions")
-    @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket or catalog object not found"),
-                            @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied") })
+    @Operation(summary = "Lists a catalog object revisions")
+    @ApiResponses(value = { @ApiResponse(responseCode = "404", description = "Bucket or catalog object not found"),
+                            @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied") })
     @RequestMapping(method = GET)
     @ResponseStatus(HttpStatus.OK)
     public List<CatalogObjectMetadata> list(
-            @ApiParam(value = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
-            @PathVariable String bucketName, @PathVariable String name)
+            @Parameter(description = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
+            @Parameter(description = "The name of the existing Bucket", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable String bucketName,
+            @Parameter(description = "The name of the existing Object", required = true, schema = @Schema(pattern = ObjectNameValidator.VALID_OBJECT_NAME_PATTERN)) @PathVariable String name)
             throws UnsupportedEncodingException, NotAuthenticatedException, AccessDeniedException {
         // Check Grants
         AuthenticatedUser user;
@@ -267,16 +265,18 @@ public class CatalogObjectRevisionController {
         return catalogObjectMetadataList;
     }
 
-    @ApiOperation(value = "Restore a catalog object revision")
-    @ApiResponses(value = { @ApiResponse(code = 404, message = "Bucket, object or revision not found"),
-                            @ApiResponse(code = 422, message = "Invalid catalog object JSON content supplied"),
-                            @ApiResponse(code = 401, message = "User not authenticated"),
-                            @ApiResponse(code = 403, message = "Permission denied") })
+    @Operation(summary = "Restore a catalog object revision")
+    @ApiResponses(value = { @ApiResponse(responseCode = "404", description = "Bucket, object or revision not found"),
+                            @ApiResponse(responseCode = "422", description = "Invalid catalog object JSON content supplied"),
+                            @ApiResponse(responseCode = "401", description = "User not authenticated"),
+                            @ApiResponse(responseCode = "403", description = "Permission denied") })
     @RequestMapping(value = "/{commitTimeRaw}", method = PUT)
     @ResponseStatus(HttpStatus.OK)
     public CatalogObjectMetadata restore(
-            @ApiParam(value = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
-            @PathVariable String bucketName, @PathVariable String name, @PathVariable Long commitTimeRaw)
+            @Parameter(description = "sessionID", required = true) @RequestHeader(value = "sessionID", required = true) String sessionId,
+            @Parameter(description = "The name of the existing Bucket", required = true, schema = @Schema(pattern = BucketNameValidator.VALID_BUCKET_NAME_PATTERN)) @PathVariable String bucketName,
+            @Parameter(description = "The name of the existing Object", required = true, schema = @Schema(pattern = ObjectNameValidator.VALID_OBJECT_NAME_PATTERN)) @PathVariable String name,
+            @PathVariable Long commitTimeRaw)
             throws UnsupportedEncodingException, NotAuthenticatedException, AccessDeniedException {
         String initiator = ANONYMOUS;
         if (sessionIdRequired) {

--- a/src/main/java/org/ow2/proactive/catalog/util/name/validator/BucketNameValidator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/name/validator/BucketNameValidator.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class BucketNameValidator extends NameValidator {
-    protected static final String VALID_BUCKET_NAME_PATTERN = "[a-z][a-z0-9-]{1,61}[a-z0-9]";
+    public static final String VALID_BUCKET_NAME_PATTERN = "[a-z][a-z0-9-]{1,61}[a-z0-9]";
 
     public BucketNameValidator() {
         super(VALID_BUCKET_NAME_PATTERN);

--- a/src/main/java/org/ow2/proactive/catalog/util/name/validator/KindAndContentTypeValidator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/name/validator/KindAndContentTypeValidator.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class KindAndContentTypeValidator extends NameValidator {
-    protected static final String VALID_KIND_NAME_PATTERN = "^([a-zA-Z0-9][a-zA-Z0-9_\\. ;=\\+\\-]{0,61}[a-zA-Z0-9]\\/?)+$";
+    public static final String VALID_KIND_NAME_PATTERN = "^([a-zA-Z0-9][a-zA-Z0-9_\\. ;=\\+\\-]{0,61}[a-zA-Z0-9]\\/?)+$";
 
     public KindAndContentTypeValidator() {
         super(VALID_KIND_NAME_PATTERN);

--- a/src/main/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/name/validator/ObjectNameValidator.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ObjectNameValidator extends NameValidator {
-    protected static final String VALID_OBJECT_NAME_PATTERN = "^[^\\s\\/,]+(\\s+[^\\s\\/,]+)*$";
+    public static final String VALID_OBJECT_NAME_PATTERN = "^[^\\s\\/,]+(\\s+[^\\s\\/,]+)*$";
 
     public ObjectNameValidator() {
         super(VALID_OBJECT_NAME_PATTERN);

--- a/src/main/java/org/ow2/proactive/catalog/util/name/validator/TagsValidator.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/name/validator/TagsValidator.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class TagsValidator extends NameValidator {
-    protected static final String TAGS_PATTERN = "^([a-zA-Z][\\s0-9a-zA-Z-_.\\/]+[,]*)*(?<!,)$";
+    public static final String TAGS_PATTERN = "^([a-zA-Z][\\s0-9a-zA-Z-_.\\/]+[,]*)*(?<!,)$";
 
     public TagsValidator() {
         super(TAGS_PATTERN);


### PR DESCRIPTION
Changed all Swagger annotations to their equivalent in OpenAPI 3 format

Better handle pdf reports (can now be used from the open api portal)

Add some constraints to parameters as the OpenAPI 3 format allows