### PR TITLE
Upgrade keycloak related dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,7 @@ dependencies {
     antlr 'org.antlr:antlr4:4.7.2'
 
     compile 'org.apache.tika:tika-core:1.28.5'
+
     compile 'commons-fileupload:commons-fileupload'
     compile 'org.apache.commons:commons-lang3'
     compile 'com.fasterxml.jackson.core:jackson-databind'
@@ -185,6 +186,8 @@ dependencies {
     compile 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider'
     compile 'com.fasterxml.jackson.module:jackson-module-jaxb-annotations'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor'
+    compile 'jakarta.activation:jakarta.activation-api'
+
     compile 'com.querydsl:querydsl-jpa:4.1.4'
 
     jacksonCoreLibs 'com.fasterxml.jackson.core:jackson-databind'


### PR DESCRIPTION
Upgrade the following dependencies to the versions mentioned in **bold**:

- jakarta.activation:jakarta.activation-api:**2.1.2**

- com.fasterxml.jackson.core:jackson-databind:**2.16.1**
- com.fasterxml.jackson.core:jackson-core:**2.16.1**
- com.fasterxml.jackson.core:jackson-annotations:**2.16.1**

- org.apache.httpcomponents:httpclient:**4.5.14**