### PR TITLE
Add filters to reports

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectCallGraphController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectCallGraphController.java
@@ -102,14 +102,28 @@ public class CatalogObjectCallGraphController {
             @Parameter(description = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @Parameter(description = "The name of the user who owns the Bucket") @RequestParam(value = "owner", required = false) String ownerName,
             @Parameter(description = "The kind of objects that buckets must contain") @RequestParam(value = "kind", required = false) Optional<String> kind,
-            @Parameter(description = "The Content-Type of objects that buckets must contain") @RequestParam(value = "contentType", required = false) Optional<String> contentType)
+            @Parameter(description = "The Content-Type of objects that buckets must contain") @RequestParam(value = "contentType", required = false) Optional<String> contentType,
+            @Parameter(description = "The project name of objects containing this name") @RequestParam(value = "projectName", required = false) Optional<String> projectName,
+            @Parameter(description = "The object name of objects containing this name") @RequestParam(value = "objectName", required = false) Optional<String> objectName,
+            @Parameter(description = "The bucket name of catalog objects") @RequestParam(value = "bucketName", required = false) Optional<String> bucketName,
+            @Parameter(description = "The tag of catalog objects") @RequestParam(value = "tag", required = false) Optional<String> tag,
+            @Parameter(description = "The user who last committed the catalog object") @RequestParam(value = "lastCommitBy", required = false) Optional<String> lastCommitBy,
+            @Parameter(description = "The maximum time the object was last committed") @RequestParam(value = "lastCommitTimeLessThan", required = false) Optional<Long> lastCommitTimeLessThan,
+            @Parameter(description = "The minimum time the object was last committed") @RequestParam(value = "lastCommitTimeGreater", required = false) Optional<Long> lastCommitTimeGreaterThan)
             throws NotAuthenticatedException, AccessDeniedException, IOException {
 
         List<String> authorisedBucketsNames = getListOfAuthorizedBuckets(sessionId, ownerName, kind, contentType);
+        bucketName.ifPresent(bucketNameFilter -> authorisedBucketsNames.removeIf(bName -> !bName.contains(bucketNameFilter)));
 
         byte[] content = catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(authorisedBucketsNames,
                                                                                                 kind,
-                                                                                                contentType);
+                                                                                                contentType,
+                                                                                                objectName,
+                                                                                                tag,
+                                                                                                projectName,
+                                                                                                lastCommitBy,
+                                                                                                lastCommitTimeGreaterThan,
+                                                                                                lastCommitTimeLessThan);
 
         flushResponse(response, content);
 
@@ -152,7 +166,13 @@ public class CatalogObjectCallGraphController {
                                                                                                                                  contentType))
                                             .orElse(catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(Collections.singletonList(bucketName),
                                                                                                                            kind,
-                                                                                                                           contentType));
+                                                                                                                           contentType,
+                                                                                                                           Optional.empty(),
+                                                                                                                           Optional.empty(),
+                                                                                                                           Optional.empty(),
+                                                                                                                           Optional.empty(),
+                                                                                                                           Optional.empty(),
+                                                                                                                           Optional.empty()));
         flushResponse(response, content);
 
     }

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectReportController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectReportController.java
@@ -110,7 +110,7 @@ public class CatalogObjectReportController {
             @Parameter(description = "The name of the user who owns the Bucket") @RequestParam(value = "owner", required = false) String ownerName,
             @Parameter(description = "The kind of objects that buckets must contain") @RequestParam(value = "kind", required = false) Optional<String> kind,
             @Parameter(description = "The Content-Type of objects that buckets must contain") @RequestParam(value = "contentType", required = false) Optional<String> contentType,
-            @Parameter(description = "The object name of objects containing this name") @RequestParam(value = "projectName", required = false) Optional<String> projectName,
+            @Parameter(description = "The project name of objects containing this name") @RequestParam(value = "projectName", required = false) Optional<String> projectName,
             @Parameter(description = "The object name of objects containing this name") @RequestParam(value = "objectName", required = false) Optional<String> objectName,
             @Parameter(description = "The bucket name of catalog objects") @RequestParam(value = "bucketName", required = false) Optional<String> bucketName,
             @Parameter(description = "The tag of catalog objects") @RequestParam(value = "tag", required = false) Optional<String> tag,
@@ -120,7 +120,7 @@ public class CatalogObjectReportController {
             throws NotAuthenticatedException, AccessDeniedException, IOException {
 
         List<String> authorisedBucketsNames = getListOfAuthorizedBuckets(sessionId, ownerName, kind, contentType);
-        bucketName.ifPresent(s -> authorisedBucketsNames.removeIf(bName -> !bName.equals(s)));
+        bucketName.ifPresent(bucketNameFilter -> authorisedBucketsNames.removeIf(bName -> !bName.contains(bucketNameFilter)));
 
         byte[] content = catalogObjectReportService.generateBytesReportZip(authorisedBucketsNames,
                                                                            kind,

--- a/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectReportController.java
+++ b/src/main/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectReportController.java
@@ -109,12 +109,28 @@ public class CatalogObjectReportController {
             @Parameter(description = "sessionID", required = false) @RequestHeader(value = "sessionID", required = false) String sessionId,
             @Parameter(description = "The name of the user who owns the Bucket") @RequestParam(value = "owner", required = false) String ownerName,
             @Parameter(description = "The kind of objects that buckets must contain") @RequestParam(value = "kind", required = false) Optional<String> kind,
-            @Parameter(description = "The Content-Type of objects that buckets must contain") @RequestParam(value = "contentType", required = false) Optional<String> contentType)
+            @Parameter(description = "The Content-Type of objects that buckets must contain") @RequestParam(value = "contentType", required = false) Optional<String> contentType,
+            @Parameter(description = "The object name of objects containing this name") @RequestParam(value = "projectName", required = false) Optional<String> projectName,
+            @Parameter(description = "The object name of objects containing this name") @RequestParam(value = "objectName", required = false) Optional<String> objectName,
+            @Parameter(description = "The bucket name of catalog objects") @RequestParam(value = "bucketName", required = false) Optional<String> bucketName,
+            @Parameter(description = "The tag of catalog objects") @RequestParam(value = "tag", required = false) Optional<String> tag,
+            @Parameter(description = "The user who last committed the catalog object") @RequestParam(value = "lastCommitBy", required = false) Optional<String> lastCommitBy,
+            @Parameter(description = "The maximum time the object was last committed") @RequestParam(value = "lastCommitTimeLessThan", required = false) Optional<Long> lastCommitTimeLessThan,
+            @Parameter(description = "The minimum time the object was last committed") @RequestParam(value = "lastCommitTimeGreater", required = false) Optional<Long> lastCommitTimeGreaterThan)
             throws NotAuthenticatedException, AccessDeniedException, IOException {
 
         List<String> authorisedBucketsNames = getListOfAuthorizedBuckets(sessionId, ownerName, kind, contentType);
+        bucketName.ifPresent(s -> authorisedBucketsNames.removeIf(bName -> !bName.equals(s)));
 
-        byte[] content = catalogObjectReportService.generateBytesReportZip(authorisedBucketsNames, kind, contentType);
+        byte[] content = catalogObjectReportService.generateBytesReportZip(authorisedBucketsNames,
+                                                                           kind,
+                                                                           contentType,
+                                                                           objectName,
+                                                                           tag,
+                                                                           projectName,
+                                                                           lastCommitBy,
+                                                                           lastCommitTimeGreaterThan,
+                                                                           lastCommitTimeLessThan);
 
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(ZIP_CONTENT_TYPE);

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectCallGraphService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectCallGraphService.java
@@ -58,11 +58,21 @@ public class CatalogObjectCallGraphService {
     private CatalogObjectCallGraphPDFGenerator catalogObjectCallGraphPDFGenerator;
 
     public byte[] generateBytesCallGraphForAllBucketsAsZip(List<String> authorisedBucketsNames, Optional<String> kind,
-            Optional<String> contentType) {
+            Optional<String> contentType, Optional<String> objectName, Optional<String> tag,
+            Optional<String> projectName, Optional<String> lastCommitBy, Optional<Long> lastCommitTimeGreaterThan,
+            Optional<Long> lastCommitTimeLessThan) {
 
         Map<String, List<CatalogObjectMetadata>> bucketNameCatalogObjectMetadata = catalogObjectService.listCatalogObjects(authorisedBucketsNames,
                                                                                                                            kind,
-                                                                                                                           contentType)
+                                                                                                                           contentType,
+                                                                                                                           objectName,
+                                                                                                                           tag,
+                                                                                                                           projectName,
+                                                                                                                           lastCommitBy,
+                                                                                                                           lastCommitTimeGreaterThan,
+                                                                                                                           lastCommitTimeLessThan,
+                                                                                                                           0,
+                                                                                                                           Integer.MAX_VALUE)
                                                                                                        .stream()
                                                                                                        .collect(Collectors.groupingBy(CatalogObjectMetadata::getBucketName,
                                                                                                                                       Collectors.toList()));

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectReportService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectReportService.java
@@ -60,11 +60,21 @@ public class CatalogObjectReportService {
     }
 
     public byte[] generateBytesReportZip(List<String> authorisedBucketsNames, Optional<String> kind,
-            Optional<String> contentType) {
+            Optional<String> contentType, Optional<String> objectName, Optional<String> tag,
+            Optional<String> projectName, Optional<String> lastCommitBy, Optional<Long> lastCommitTimeGreaterThan,
+            Optional<Long> lastCommitTimeLessThan) {
 
         List<CatalogObjectMetadata> metadataList = catalogObjectService.listCatalogObjects(authorisedBucketsNames,
                                                                                            kind,
-                                                                                           contentType);
+                                                                                           contentType,
+                                                                                           objectName,
+                                                                                           tag,
+                                                                                           projectName,
+                                                                                           lastCommitBy,
+                                                                                           lastCommitTimeGreaterThan,
+                                                                                           lastCommitTimeLessThan,
+                                                                                           0,
+                                                                                           Integer.MAX_VALUE);
 
         return catalogObjectReportPDFGenerator.getAllCatalogObjectsReportPDFAsArchive(new HashSet<>(metadataList),
                                                                                       kind,

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectCallGraphControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectCallGraphControllerTest.java
@@ -89,9 +89,26 @@ public class CatalogObjectCallGraphControllerTest {
         when(bucketService.listBuckets(ownerName, kind, contentType)).thenReturn(authorisedBuckets);
         when(catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(anyList(),
                                                                                     anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
                                                                                     anyObject())).thenReturn(content);
 
-        CatalogObjectCallGraphController.getCallGraph(response, "sessionid", "xxx", Optional.empty(), Optional.empty());
+        CatalogObjectCallGraphController.getCallGraph(response,
+                                                      "sessionid",
+                                                      "xxx",
+                                                      Optional.empty(),
+                                                      Optional.empty(),
+                                                      Optional.empty(),
+                                                      Optional.empty(),
+                                                      Optional.empty(),
+                                                      Optional.empty(),
+                                                      Optional.empty(),
+                                                      Optional.empty(),
+                                                      Optional.empty());
         verify(response, times(1)).addHeader("Content-size", new Integer(content.length).toString());
         verify(response, times(1)).setCharacterEncoding("UTF-8");
 
@@ -153,6 +170,12 @@ public class CatalogObjectCallGraphControllerTest {
         when(response.getOutputStream()).thenReturn(sos);
 
         when(catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(anyList(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
+                                                                                    anyObject(),
                                                                                     anyObject(),
                                                                                     anyObject())).thenReturn(content);
 

--- a/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectReportControllerTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/rest/controller/CatalogObjectReportControllerTest.java
@@ -90,9 +90,26 @@ public class CatalogObjectReportControllerTest {
         when(bucketService.listBuckets(ownerName, kind, contentType)).thenReturn(authorisedBuckets);
         when(catalogObjectReportService.generateBytesReportZip(anyList(),
                                                                anyObject(),
+                                                               anyObject(),
+                                                               anyObject(),
+                                                               anyObject(),
+                                                               anyObject(),
+                                                               anyObject(),
+                                                               anyObject(),
                                                                anyObject())).thenReturn(content);
 
-        catalogObjectReportController.getReport(response, "sessionid", "xxx", Optional.empty(), Optional.empty());
+        catalogObjectReportController.getReport(response,
+                                                "sessionid",
+                                                "xxx",
+                                                Optional.empty(),
+                                                Optional.empty(),
+                                                Optional.empty(),
+                                                Optional.empty(),
+                                                Optional.empty(),
+                                                Optional.empty(),
+                                                Optional.empty(),
+                                                Optional.empty(),
+                                                Optional.empty());
         verify(response, times(1)).addHeader(HttpHeaders.CONTENT_DISPOSITION,
                                              "attachment; filename=\"catalog_report.zip\"");
         verify(response, times(1)).addHeader(HttpHeaders.CONTENT_ENCODING, "binary");

--- a/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectCallGraphServiceTest.java
+++ b/src/test/java/org/ow2/proactive/catalog/service/CatalogObjectCallGraphServiceTest.java
@@ -105,7 +105,13 @@ public class CatalogObjectCallGraphServiceTest {
 
         byte[] content = catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(authorisedBucketsNames,
                                                                                                 kind,
-                                                                                                contentType);
+                                                                                                contentType,
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty());
 
         assertThat(content).isNotNull();
     }
@@ -159,7 +165,13 @@ public class CatalogObjectCallGraphServiceTest {
 
         byte[] content = catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(authorisedBucketsNames,
                                                                                                 kind,
-                                                                                                contentType);
+                                                                                                contentType,
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty());
 
         assertThat(content).isNotNull();
     }
@@ -185,7 +197,13 @@ public class CatalogObjectCallGraphServiceTest {
 
         byte[] content = catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(authorisedBucketsNames,
                                                                                                 kind,
-                                                                                                contentType);
+                                                                                                contentType,
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty());
 
         assertThat(content).isNotNull();
     }
@@ -211,7 +229,13 @@ public class CatalogObjectCallGraphServiceTest {
 
         byte[] content = catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(authorisedBucketsNames,
                                                                                                 kind,
-                                                                                                contentType);
+                                                                                                contentType,
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty());
 
         assertThat(content).isNotNull();
     }
@@ -233,7 +257,13 @@ public class CatalogObjectCallGraphServiceTest {
 
         byte[] content = catalogObjectCallGraphService.generateBytesCallGraphForAllBucketsAsZip(authorisedBucketsNames,
                                                                                                 kind,
-                                                                                                contentType);
+                                                                                                contentType,
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty(),
+                                                                                                Optional.empty());
 
         assertThat(content).isNotNull();
 


### PR DESCRIPTION
Allow to generate a PDF report and a Call Graph report for the currentcatalog object displayed (with filters)