### PR TITLE
Add description to get metadata of calendars

### DIFF
--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -807,7 +807,6 @@ public class CatalogObjectService {
     public CatalogObjectMetadata getCatalogObjectMetadata(String bucketName, String name) {
         CatalogObjectRevisionEntity revisionEntity = findCatalogObjectByNameAndBucketAndCheck(bucketName, name);
         CatalogObjectMetadata metadata = new CatalogObjectMetadata(revisionEntity);
-        // If we are fetching the metadata of a calendar object, we read the description from the raw object and add it to the keyValueMetadataList
         if (StringUtils.equalsIgnoreCase(metadata.getKind(), CALENDAR.toString())) {
             addDescriptionMetadataToCalendar(revisionEntity, metadata);
         }

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -26,7 +26,6 @@
 package org.ow2.proactive.catalog.service;
 
 import static org.ow2.proactive.catalog.util.AccessType.write;
-import static org.ow2.proactive.catalog.util.parser.SupportedParserKinds.CALENDAR;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -805,11 +804,7 @@ public class CatalogObjectService {
     @Transactional(readOnly = true)
     public CatalogObjectMetadata getCatalogObjectMetadata(String bucketName, String name) {
         CatalogObjectRevisionEntity revisionEntity = findCatalogObjectByNameAndBucketAndCheck(bucketName, name);
-        CatalogObjectMetadata metadata = new CatalogObjectMetadata(revisionEntity);
-        if (StringUtils.equalsIgnoreCase(metadata.getKind(), CALENDAR.toString())) {
-            addDescriptionMetadataToCalendar(revisionEntity, metadata);
-        }
-        return metadata;
+        return new CatalogObjectMetadata(revisionEntity);
     }
 
     @Transactional(readOnly = true)
@@ -904,10 +899,6 @@ public class CatalogObjectService {
         CatalogObjectRevisionEntity revisionEntity = getCatalogObjectRevisionEntityByCommitTime(bucketName,
                                                                                                 name,
                                                                                                 commitTime);
-        CatalogObjectMetadata metadata = new CatalogObjectMetadata(revisionEntity);
-        if (StringUtils.equalsIgnoreCase(metadata.getKind(), CALENDAR.toString())) {
-            addDescriptionMetadataToCalendar(revisionEntity, metadata);
-        }
         return new CatalogObjectMetadata(revisionEntity);
     }
 
@@ -1007,18 +998,6 @@ public class CatalogObjectService {
                       .flatMap(Collection::stream)
                       .sorted()
                       .collect(Collectors.toList());
-    }
-
-    private void addDescriptionMetadataToCalendar(CatalogObjectRevisionEntity revisionEntity,
-            CatalogObjectMetadata metadata) {
-        if (revisionEntity.getRawObject() != null) {
-            List<Metadata> metadataList = keyValueLabelMetadataHelper.extractKeyValuesFromRaw(metadata.getKind(),
-                                                                                              revisionEntity.getRawObject())
-                                                                     .stream()
-                                                                     .map(Metadata::new)
-                                                                     .collect(Collectors.toList());
-            metadata.getMetadataList().addAll(metadataList);
-        }
     }
 
     private Map<String, List<CatalogObjectNameReference>>

--- a/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
+++ b/src/main/java/org/ow2/proactive/catalog/service/CatalogObjectService.java
@@ -76,7 +76,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -807,8 +806,7 @@ public class CatalogObjectService {
     public CatalogObjectMetadata getCatalogObjectMetadata(String bucketName, String name) {
         CatalogObjectRevisionEntity revisionEntity = findCatalogObjectByNameAndBucketAndCheck(bucketName, name);
         CatalogObjectMetadata metadata = new CatalogObjectMetadata(revisionEntity);
-        if (StringUtils.equalsIgnoreCase(metadata.getKind(), CALENDAR.toString()) &&
-            revisionEntity.getRawObject() != null) {
+        if (StringUtils.equalsIgnoreCase(metadata.getKind(), CALENDAR.toString())) {
             addDescriptionMetadataToCalendar(revisionEntity, metadata);
         }
         return metadata;
@@ -907,8 +905,7 @@ public class CatalogObjectService {
                                                                                                 name,
                                                                                                 commitTime);
         CatalogObjectMetadata metadata = new CatalogObjectMetadata(revisionEntity);
-        if (StringUtils.equalsIgnoreCase(metadata.getKind(), CALENDAR.toString()) &&
-            revisionEntity.getRawObject() != null) {
+        if (StringUtils.equalsIgnoreCase(metadata.getKind(), CALENDAR.toString())) {
             addDescriptionMetadataToCalendar(revisionEntity, metadata);
         }
         return new CatalogObjectMetadata(revisionEntity);

--- a/src/main/java/org/ow2/proactive/catalog/util/parser/CalendarDefinitionParser.java
+++ b/src/main/java/org/ow2/proactive/catalog/util/parser/CalendarDefinitionParser.java
@@ -28,9 +28,13 @@ package org.ow2.proactive.catalog.util.parser;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
+import org.ow2.proactive.catalog.dto.Metadata;
 import org.ow2.proactive.catalog.repository.entity.KeyValueLabelMetadataEntity;
 import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -45,6 +49,8 @@ import lombok.extern.log4j.Log4j2;
 
 public final class CalendarDefinitionParser extends AbstractCatalogObjectParser {
 
+    public static final String DESCRIPTION_KEY = "description";
+
     @Override
     public boolean isMyKind(String kind) {
         return kind.toLowerCase().startsWith(SupportedParserKinds.CALENDAR.toString().toLowerCase());
@@ -57,6 +63,16 @@ public final class CalendarDefinitionParser extends AbstractCatalogObjectParser 
 
     @Override
     List<KeyValueLabelMetadataEntity> getMetadataKeyValues(InputStream inputStream) {
-        return new ArrayList<>();
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<KeyValueLabelMetadataEntity> result = new ArrayList<>(1);
+        try {
+            Map<String, String> parse = objectMapper.readValue(inputStream, Map.class);
+            if (parse.containsKey(DESCRIPTION_KEY)) {
+                result.add(new KeyValueLabelMetadataEntity(DESCRIPTION_KEY, parse.get(DESCRIPTION_KEY), "General"));
+            }
+        } catch (Exception e) {
+            log.warn("Error when reading calendar's raw object (JSON). Returning object without description");
+        }
+        return result;
     }
 }


### PR DESCRIPTION
When retrieving metada of calendar catalog objetcs, we read the raw object (JSON) and add its description in the metadata list.